### PR TITLE
fix: check if response is not nil

### DIFF
--- a/cmd/edge_services/create/create.go
+++ b/cmd/edge_services/create/create.go
@@ -58,7 +58,7 @@ func createNewService(client *sdk.APIClient, out io.Writer, name string, verbose
 
 	resp, httpResp, err := api.NewService(c).CreateServiceRequest(serviceRequest).Execute()
 	if err != nil {
-		if httpResp.StatusCode >= 500 {
+		if httpResp != nil && httpResp.StatusCode >= 500 {
 			return utils.ErrorInternalServerError
 		}
 

--- a/cmd/edge_services/delete/delete.go
+++ b/cmd/edge_services/delete/delete.go
@@ -58,7 +58,7 @@ func deleteService(client *sdk.APIClient, out io.Writer, service_id int64, verbo
 	httpResp, err := api.DeleteService(c, service_id).Execute()
 
 	if err != nil {
-		if httpResp.StatusCode >= 500 {
+		if httpResp != nil && httpResp.StatusCode >= 500 {
 			return utils.ErrorInternalServerError
 		}
 		return err

--- a/cmd/edge_services/describe/describe.go
+++ b/cmd/edge_services/describe/describe.go
@@ -61,7 +61,7 @@ func describeService(client *sdk.APIClient, out io.Writer, service_id int64, wit
 
 	resp, httpResp, err := api.GetService(c, service_id).WithVars(withVariables).Execute()
 	if err != nil {
-		if httpResp.StatusCode >= 500 {
+		if httpResp != nil && httpResp.StatusCode >= 500 {
 			return utils.ErrorInternalServerError
 		}
 		return err

--- a/cmd/edge_services/list/list.go
+++ b/cmd/edge_services/list/list.go
@@ -61,7 +61,7 @@ func listAllServices(client *sdk.APIClient, out io.Writer, opts *ListOptions) er
 		Execute()
 
 	if err != nil {
-		if httpResp.StatusCode >= 500 {
+		if httpResp != nil && httpResp.StatusCode >= 500 {
 			return utils.ErrorInternalServerError
 		}
 		return err

--- a/cmd/edge_services/resources/create/create.go
+++ b/cmd/edge_services/resources/create/create.go
@@ -107,7 +107,7 @@ func createNewResource(client *sdk.APIClient, out io.Writer, service_id int64, n
 
 	resp, httpResp, err := api.PostResource(c, service_id).CreateResourceRequest(request).Execute()
 	if err != nil {
-		if httpResp.StatusCode >= 500 {
+		if httpResp != nil && httpResp.StatusCode >= 500 {
 			return utils.ErrorInternalServerError
 		}
 		body, err := ioutil.ReadAll(httpResp.Body)

--- a/cmd/edge_services/resources/delete/delete.go
+++ b/cmd/edge_services/resources/delete/delete.go
@@ -57,7 +57,7 @@ func deleteResource(client *sdk.APIClient, out io.Writer, service_id int64, reso
 
 	httpResp, err := api.DeleteResource(c, service_id, resource_id).Execute()
 	if err != nil {
-		if httpResp.StatusCode >= 500 {
+		if httpResp != nil && httpResp.StatusCode >= 500 {
 			return utils.ErrorInternalServerError
 		}
 		return err

--- a/cmd/edge_services/resources/describe/describe.go
+++ b/cmd/edge_services/resources/describe/describe.go
@@ -54,7 +54,7 @@ func describeResource(client *sdk.APIClient, out io.Writer, service_id int64, re
 
 	resp, httpResp, err := api.GetResource(c, service_id, resource_id).Execute()
 	if err != nil {
-		if httpResp.StatusCode >= 500 {
+		if httpResp != nil && httpResp.StatusCode >= 500 {
 			return utils.ErrorInternalServerError
 		}
 		return err

--- a/cmd/edge_services/resources/list/list.go
+++ b/cmd/edge_services/resources/list/list.go
@@ -70,7 +70,7 @@ func listAllResources(client *sdk.APIClient, out io.Writer, opts *ListOptions, s
 		Execute()
 
 	if err != nil {
-		if httpResp.StatusCode >= 500 {
+		if httpResp != nil && httpResp.StatusCode >= 500 {
 			return utils.ErrorInternalServerError
 		}
 		return err

--- a/cmd/edge_services/resources/update/update.go
+++ b/cmd/edge_services/resources/update/update.go
@@ -120,7 +120,7 @@ func updateResource(client *sdk.APIClient, out io.Writer, service_id int64, reso
 
 	resp, httpResp, err := api.PatchServiceResource(c, service_id, resource_id).UpdateResourceRequest(update).Execute()
 	if err != nil {
-		if httpResp.StatusCode >= 500 {
+		if httpResp != nil && httpResp.StatusCode >= 500 {
 			return utils.ErrorInternalServerError
 		}
 		body, err := ioutil.ReadAll(httpResp.Body)

--- a/cmd/edge_services/update/update.go
+++ b/cmd/edge_services/update/update.go
@@ -118,7 +118,7 @@ func updateService(client *sdk.APIClient, out io.Writer, id int64, cmd *cobra.Co
 
 	resp, httpResp, err := api.PatchService(c, id).UpdateServiceRequest(serviceRequest).Execute()
 	if err != nil {
-		if httpResp.StatusCode >= 500 {
+		if httpResp != nil && httpResp.StatusCode >= 500 {
 			return utils.ErrorInternalServerError
 		}
 


### PR DESCRIPTION
## What
Check if HTTP response is non-nil

## Why
If we don't, we might get segmentation faults when some errors occur:
```
> bin/azioncli edge_services list
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x1302db3]

goroutine 1 [running]:
github.com/aziontech/azion-cli/cmd/edge_services/list.listAllServices(0xc00004cef0, {0x141ea60, 0xc000010018}, 0xc000013170)
        /Users/fm/Code/azion-cli/cmd/edge_services/list/list.go:64 +0x253
github.com/aziontech/azion-cli/cmd/edge_services/list.NewCmd.func1(0xc000154000, {0x139b8b0, 0x0, 0x0})
        /Users/fm/Code/azion-cli/cmd/edge_services/list/list.go:39 +0x51
github.com/spf13/cobra.(*Command).execute(0xc000154000, {0x16a56c0, 0x0, 0x0})
        /Users/fm/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:856 +0x60e
github.com/spf13/cobra.(*Command).ExecuteC(0xc00011cc80)
        /Users/fm/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:974 +0x3bc
github.com/spf13/cobra.(*Command).Execute(...)
        /Users/fm/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:902
github.com/aziontech/azion-cli/cmd.Execute()
        /Users/fm/Code/azion-cli/cmd/root.go:55 +0xea
main.main()
        /Users/fm/Code/azion-cli/main.go:8 +0x17
```