### PR TITLE
fix: small fix to usage messages

### DIFF
--- a/cmd/edge_services/create/create.go
+++ b/cmd/edge_services/create/create.go
@@ -15,7 +15,7 @@ import (
 func NewCmd(f *cmdutil.Factory) *cobra.Command {
 	// listCmd represents the list command
 	createCmd := &cobra.Command{
-		Use:           "create",
+		Use:           "create [flags]",
 		Short:         "Creates a new edge service",
 		Long:          `Creates a new edge service with the received name`,
 		SilenceUsage:  true,

--- a/cmd/edge_services/delete/delete.go
+++ b/cmd/edge_services/delete/delete.go
@@ -15,7 +15,7 @@ import (
 func NewCmd(f *cmdutil.Factory) *cobra.Command {
 	// deleteCmd represents the delete command
 	deleteCmd := &cobra.Command{
-		Use:           "delete",
+		Use:           "delete <service_id> [flags]",
 		Short:         "Deletes a service based on a given service_id",
 		Long:          `Deletes a service based on a given service_id`,
 		SilenceUsage:  true,

--- a/cmd/edge_services/describe/describe.go
+++ b/cmd/edge_services/describe/describe.go
@@ -16,7 +16,7 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 
 	// describeCmd represents the describe command
 	describeCmd := &cobra.Command{
-		Use:           "describe",
+		Use:           "describe <service_id> [flags]",
 		Short:         "Describes a service based on a given service_id",
 		Long:          `Describes a service based on a given service_id`,
 		SilenceUsage:  true,

--- a/cmd/edge_services/list/list.go
+++ b/cmd/edge_services/list/list.go
@@ -25,7 +25,7 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 
 	// listCmd represents the list command
 	listCmd := &cobra.Command{
-		Use:           "list",
+		Use:           "list [flags]",
 		Short:         "Lists services of an Azion account",
 		Long:          `Lists services of an Azion account`,
 		SilenceUsage:  true,

--- a/cmd/edge_services/resources/create/create.go
+++ b/cmd/edge_services/resources/create/create.go
@@ -19,7 +19,7 @@ const SHELL_SCRIPT string = "Shell Script"
 func NewCmd(f *cmdutil.Factory) *cobra.Command {
 	// createCmd represents the create command
 	createCmd := &cobra.Command{
-		Use:           "create",
+		Use:           "create <service_id> [flags]",
 		Short:         "Creates a new resource",
 		Long:          `Creates a new resource in an Edge Service based on a giver servce_id.`,
 		SilenceUsage:  true,
@@ -83,10 +83,10 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 		},
 	}
 
-	createCmd.Flags().StringP("name", "n", "", "<PATH>/<RESOURCE_NAME>")
+	createCmd.Flags().String("name", "", "<PATH>/<RESOURCE_NAME>")
 	_ = createCmd.MarkFlagRequired("name")
 	createCmd.Flags().String("trigger", "", "<Install|Reload|Uninstall>")
-	createCmd.Flags().String("content-type", "", "<\"Shell Script\"|\"Text\"")
+	createCmd.Flags().String("content-type", "", "<\"Shell Script\"|\"Text\">")
 	_ = createCmd.MarkFlagRequired("content-type")
 	createCmd.Flags().String("content-file", "", "Absolute path to where the file with the content is located at")
 	_ = createCmd.MarkFlagRequired("content-file")

--- a/cmd/edge_services/resources/delete/delete.go
+++ b/cmd/edge_services/resources/delete/delete.go
@@ -15,8 +15,8 @@ import (
 func NewCmd(f *cmdutil.Factory) *cobra.Command {
 	// deleteCmd represents the delete command
 	deleteCmd := &cobra.Command{
-		Use:           "delete",
-		Short:         "Deletes a resource based on a given resource_id",
+		Use:           "delete <service_id> <resource_id> [flags]",
+		Short:         "Deletes a resource based on a given service_id and a resource_id",
 		Long:          `Deletes a resource when given a service_id and a resource_id`,
 		SilenceUsage:  true,
 		SilenceErrors: true,

--- a/cmd/edge_services/resources/describe/describe.go
+++ b/cmd/edge_services/resources/describe/describe.go
@@ -16,9 +16,9 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 
 	// describeCmd represents the describe command
 	describeCmd := &cobra.Command{
-		Use:           "describe",
+		Use:           "describe <service_id> <resource_id> [flags]",
 		Short:         "Describes a resource based on a given resource_id",
-		Long:          `Provides a long desription of a resource based on a given resource_id`,
+		Long:          `Provides a long desription of a resource based on a given service_id and a resource_id`,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/edge_services/resources/list/list.go
+++ b/cmd/edge_services/resources/list/list.go
@@ -25,9 +25,9 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 
 	// listCmd represents the list command
 	listCmd := &cobra.Command{
-		Use:           "list",
+		Use:           "list <service_id> [flags]",
 		Short:         "Lists resources in a given service",
-		Long:          `Lists all resources found in a service by providing a service_id. Service_id can be found by listing your services`,
+		Long:          `Lists all resources found in a service by providing a service_id`,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/edge_services/resources/update/update.go
+++ b/cmd/edge_services/resources/update/update.go
@@ -19,7 +19,7 @@ const SHELL_SCRIPT string = "Shell Script"
 func NewCmd(f *cmdutil.Factory) *cobra.Command {
 	// updateCmd represents the update command
 	updateCmd := &cobra.Command{
-		Use:           "update",
+		Use:           "update <service_id> <resource_id> [flags]",
 		Short:         "Updates a resource based on a resource_id",
 		Long:          `Updates fields of a resource based on a service_id and resource_id`,
 		SilenceUsage:  true,
@@ -108,7 +108,7 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 
 	updateCmd.Flags().String("name", "", "<PATH>/<RESOURCE_NAME>")
 	updateCmd.Flags().String("trigger", "", "<Install|Reload|Uninstall>")
-	updateCmd.Flags().String("content-type", "", "<\"Shell Script\"|\"Text\"")
+	updateCmd.Flags().String("content-type", "", "<\"Shell Script\"|\"Text\">")
 	updateCmd.Flags().String("content-file", "", "Absolute path to where the file with the content is located at")
 
 	return updateCmd

--- a/cmd/edge_services/update/update.go
+++ b/cmd/edge_services/update/update.go
@@ -20,7 +20,7 @@ import (
 func NewCmd(f *cmdutil.Factory) *cobra.Command {
 	// listCmd represents the list command
 	updateCmd := &cobra.Command{
-		Use:           "update",
+		Use:           "update <service_id> [flags]",
 		Short:         "Updates parameters of an edge service",
 		Long:          `Updates parameters of an edge service`,
 		SilenceUsage:  true,


### PR DESCRIPTION
**WHAT**
Fix to usage messages, so they are clear that a `service_id` and a `resource_id` are required.

**WHY**
[NO ISSUE]