### PR TITLE
[ENG-18862] feat: publish docs to wiki

### DIFF
--- a/.github/workflows/generate_docs.yml
+++ b/.github/workflows/generate_docs.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - master
-      - docs-to-wiki
 
 jobs:
   build:


### PR DESCRIPTION
**WHAT**
Publish CLI docs to wiki on push to master
Implementation of doc generation was done through this PR: https://github.com/aziontech/azion-cli/pull/24

**WHY**
[ENG-18862]


[ENG-18862]: https://aziontech.atlassian.net/browse/ENG-18862?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ