### PR TITLE
[ENG-18983] chore: use slugs instead of strings

### DIFF
--- a/cmd/edge_services/resources/create/create.go
+++ b/cmd/edge_services/resources/create/create.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"strings"
 
 	"github.com/aziontech/azion-cli/cmd/edge_services/requests"
 	"github.com/aziontech/azion-cli/pkg/cmdutil"
@@ -34,21 +35,25 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 				return utils.ErrorConvertingIdArgumentToInt
 			}
 
+			replacer := strings.NewReplacer("shellscript", "Shell Script", "text", "Text", "install", "Install", "reload", "Reload", "uninstall", "Uninstall")
+
 			name, err := cmd.Flags().GetString("name")
 			if err != nil {
 				return err
 			}
 
 			trigger, err := cmd.Flags().GetString("trigger")
+			triggerConverted := replacer.Replace(trigger)
 			if err != nil {
 				return err
 			}
 
-			content_type, err := cmd.Flags().GetString("content-type")
+			contentType, err := cmd.Flags().GetString("content-type")
 			if err != nil {
 				return err
 			}
-			if content_type == SHELL_SCRIPT {
+			contentTypeConverted := replacer.Replace(contentType)
+			if contentTypeConverted == SHELL_SCRIPT {
 				if trigger == "" {
 					return utils.ErrorInvalidResourceTrigger
 				}
@@ -75,7 +80,7 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if err := createNewResource(client, f.IOStreams.Out, ids[0], name, trigger, content_type, stringFile, verbose); err != nil {
+			if err := createNewResource(client, f.IOStreams.Out, ids[0], name, triggerConverted, contentTypeConverted, stringFile, verbose); err != nil {
 				return fmt.Errorf("%v. %v", err, utils.GenericUseHelp)
 			}
 
@@ -86,7 +91,7 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 	createCmd.Flags().String("name", "", "<PATH>/<RESOURCE_NAME>")
 	_ = createCmd.MarkFlagRequired("name")
 	createCmd.Flags().String("trigger", "", "<Install|Reload|Uninstall>")
-	createCmd.Flags().String("content-type", "", "<\"Shell Script\"|\"Text\">")
+	createCmd.Flags().String("content-type", "", "<shellscript|text>")
 	_ = createCmd.MarkFlagRequired("content-type")
 	createCmd.Flags().String("content-file", "", "Absolute path to where the file with the content is located at")
 	_ = createCmd.MarkFlagRequired("content-file")
@@ -94,14 +99,14 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 	return createCmd
 }
 
-func createNewResource(client *sdk.APIClient, out io.Writer, service_id int64, name string, trigger string, content_type string, file string, verbose bool) error {
+func createNewResource(client *sdk.APIClient, out io.Writer, service_id int64, name string, trigger string, contentType string, file string, verbose bool) error {
 	c := context.Background()
 	api := client.DefaultApi
 
 	request := sdk.CreateResourceRequest{
 		Name:        name,
 		Trigger:     trigger,
-		ContentType: content_type,
+		ContentType: contentType,
 		Content:     file,
 	}
 

--- a/cmd/edge_services/resources/create/create_test.go
+++ b/cmd/edge_services/resources/create/create_test.go
@@ -65,7 +65,7 @@ func TestCreate(t *testing.T) {
 
 		cmd := NewCmd(f)
 		cmd.PersistentFlags().BoolP("verbose", "v", false, "")
-		cmd.SetArgs([]string{"-v", "1234", "--name", "/tmp/testando.txt", "--content-type", "Text", "--content-file", contentFile.Name()})
+		cmd.SetArgs([]string{"-v", "1234", "--name", "/tmp/testando.txt", "--content-type", "text", "--content-file", contentFile.Name()})
 		cmd.SetIn(&bytes.Buffer{})
 		cmd.SetOut(ioutil.Discard)
 		cmd.SetErr(ioutil.Discard)
@@ -100,7 +100,7 @@ func TestCreate(t *testing.T) {
 
 		cmd := NewCmd(f)
 		cmd.PersistentFlags().BoolP("verbose", "v", false, "")
-		cmd.SetArgs([]string{"1234", "--name", "/tmp/testando.txt", "--content-type", "Text", "--content-file", contentFile.Name()})
+		cmd.SetArgs([]string{"1234", "--name", "/tmp/testando.txt", "--content-type", "text", "--content-file", contentFile.Name()})
 		cmd.SetIn(&bytes.Buffer{})
 		cmd.SetOut(ioutil.Discard)
 		cmd.SetErr(ioutil.Discard)
@@ -134,7 +134,7 @@ func TestCreate(t *testing.T) {
 
 		cmd := NewCmd(f)
 		cmd.PersistentFlags().BoolP("verbose", "v", false, "")
-		cmd.SetArgs([]string{"1234", "--name", "/tmp/bomb.sh", "--trigger", "Install", "--content-type", "Shell Script", "--content-file", contentFile.Name()})
+		cmd.SetArgs([]string{"1234", "--name", "/tmp/bomb.sh", "--trigger", "Install", "--content-type", "shellscript", "--content-file", contentFile.Name()})
 		cmd.SetIn(&bytes.Buffer{})
 		cmd.SetOut(ioutil.Discard)
 		cmd.SetErr(ioutil.Discard)
@@ -151,7 +151,7 @@ func TestCreate(t *testing.T) {
 
 		cmd := NewCmd(f)
 
-		cmd.SetArgs([]string{"1234", "--name", "/tmp/bomb.sh", "--content-type", "Shell Script", "--content-file", contentFile.Name()})
+		cmd.SetArgs([]string{"1234", "--name", "/tmp/bomb.sh", "--content-type", "shellscript", "--content-file", contentFile.Name()})
 		cmd.SetIn(&bytes.Buffer{})
 		cmd.SetOut(ioutil.Discard)
 		cmd.SetErr(ioutil.Discard)
@@ -166,7 +166,7 @@ func TestCreate(t *testing.T) {
 
 		cmd := NewCmd(f)
 
-		cmd.SetArgs([]string{"1234", "--name", "/tmp/a.txt", "--content-type", "Text"})
+		cmd.SetArgs([]string{"1234", "--name", "/tmp/a.txt", "--content-type", "text"})
 		cmd.SetIn(&bytes.Buffer{})
 		cmd.SetOut(ioutil.Discard)
 		cmd.SetErr(ioutil.Discard)
@@ -188,7 +188,7 @@ func TestCreate(t *testing.T) {
 
 		cmd := NewCmd(f)
 
-		cmd.SetArgs([]string{"1234", "--name", "/tmp/a.txt", "--content-type", "Text", "--content-file", contentFile.Name()})
+		cmd.SetArgs([]string{"1234", "--name", "/tmp/a.txt", "--content-type", "text", "--content-file", contentFile.Name()})
 		cmd.SetIn(&bytes.Buffer{})
 		cmd.SetOut(ioutil.Discard)
 		cmd.SetErr(ioutil.Discard)

--- a/cmd/edge_services/resources/update/update.go
+++ b/cmd/edge_services/resources/update/update.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"strings"
 
 	"github.com/aziontech/azion-cli/cmd/edge_services/requests"
 	"github.com/aziontech/azion-cli/pkg/cmdutil"
@@ -35,6 +36,8 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 				return utils.ErrorConvertingIdArgumentToInt
 			}
 
+			replacer := strings.NewReplacer("shellscript", "Shell Script", "text", "Text", "install", "Install", "reload", "Reload", "uninstall", "Uninstall")
+
 			updateRequest := sdk.UpdateResourceRequest{}
 			valueHasChanged := false
 
@@ -52,7 +55,8 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 				if err != nil {
 					return err
 				}
-				updateRequest.SetTrigger(trigger)
+				triggerConverted := replacer.Replace(trigger)
+				updateRequest.SetTrigger(triggerConverted)
 				updateRequest.SetContentType(SHELL_SCRIPT)
 				valueHasChanged = true
 			}
@@ -62,7 +66,8 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 				if err != nil {
 					return err
 				}
-				updateRequest.SetContentType(contentType)
+				contentTypeConverted := replacer.Replace(contentType)
+				updateRequest.SetContentType(contentTypeConverted)
 				valueHasChanged = true
 			}
 
@@ -108,7 +113,7 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 
 	updateCmd.Flags().String("name", "", "<PATH>/<RESOURCE_NAME>")
 	updateCmd.Flags().String("trigger", "", "<Install|Reload|Uninstall>")
-	updateCmd.Flags().String("content-type", "", "<\"Shell Script\"|\"Text\">")
+	updateCmd.Flags().String("content-type", "", "<shellscript|text>")
 	updateCmd.Flags().String("content-file", "", "Absolute path to where the file with the content is located at")
 
 	return updateCmd

--- a/cmd/edge_services/resources/update/update_test.go
+++ b/cmd/edge_services/resources/update/update_test.go
@@ -137,7 +137,7 @@ func TestUpdate(t *testing.T) {
 
 		cmd := NewCmd(f)
 		cmd.PersistentFlags().BoolP("verbose", "v", false, "")
-		cmd.SetArgs([]string{"1234", "666", "--name", "BIRL", "--trigger", "Install", "--content-type", "Shell Script", "--content-file", contentFile.Name()})
+		cmd.SetArgs([]string{"1234", "666", "--name", "BIRL", "--trigger", "Install", "--content-type", "shellscript", "--content-file", contentFile.Name()})
 		cmd.SetIn(&bytes.Buffer{})
 		cmd.SetOut(ioutil.Discard)
 		cmd.SetErr(ioutil.Discard)
@@ -176,7 +176,7 @@ func TestUpdate(t *testing.T) {
 
 		cmd := NewCmd(f)
 		cmd.PersistentFlags().BoolP("verbose", "v", false, "")
-		cmd.SetArgs([]string{"1234", "666", "-v", "--name", "BIRL", "--trigger", "Install", "--content-type", "Shell Script", "--content-file", contentFile.Name()})
+		cmd.SetArgs([]string{"1234", "666", "-v", "--name", "BIRL", "--trigger", "Install", "--content-type", "shellscript", "--content-file", contentFile.Name()})
 		cmd.SetIn(&bytes.Buffer{})
 		cmd.SetOut(ioutil.Discard)
 		cmd.SetErr(ioutil.Discard)


### PR DESCRIPTION
**WHAT**
- Use slugs `shellscript` and `text` instead of strings.
- Convert install, reload and uninstall when they are send with lowercase letter in the beginning.

**WHY**
[ENG-18983]

[ENG-18983]: https://aziontech.atlassian.net/browse/ENG-18983?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ