### PR TITLE
[ENG-19102] fix: correct description for list command

### DIFF
--- a/pkg/cmd/edge_services/list/list.go
+++ b/pkg/cmd/edge_services/list/list.go
@@ -44,8 +44,8 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 		},
 	}
 
-	listCmd.Flags().Int64Var(&opts.Limit, "limit", 10, "Maximum number of items to fetch (default 10)")
-	listCmd.Flags().Int64Var(&opts.Page, "page", 1, "Select the page from results (default 1)")
+	listCmd.Flags().Int64Var(&opts.Limit, "limit", 10, "Maximum number of items to fetch")
+	listCmd.Flags().Int64Var(&opts.Page, "page", 1, "Select the page from results")
 	listCmd.Flags().StringVar(&opts.Filter, "filter", "", "Filter results by their name")
 	listCmd.Flags().BoolVar(&opts.Details, "details", false, "Show all relevant fields when listing")
 

--- a/pkg/cmd/edge_services/resources/list/list.go
+++ b/pkg/cmd/edge_services/resources/list/list.go
@@ -53,8 +53,8 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 		},
 	}
 
-	listCmd.Flags().Int64Var(&opts.Limit, "limit", 10, "Maximum number of items to fetch (default 10)")
-	listCmd.Flags().Int64Var(&opts.Page, "page", 1, "Select the page from results (default 1)")
+	listCmd.Flags().Int64Var(&opts.Limit, "limit", 10, "Maximum number of items to fetch")
+	listCmd.Flags().Int64Var(&opts.Page, "page", 1, "Select the page from results")
 	listCmd.Flags().StringVar(&opts.Filter, "filter", "", "Filter results by their name")
 	listCmd.Flags().BoolVar(&opts.Details, "details", false, "Show all relevant fields when listing")
 


### PR DESCRIPTION
**WHAT**
We do not need to specify defaults for flags as cobra does that automatically. 

WHY
[ENG-19102]

[ENG-19102]: https://aziontech.atlassian.net/browse/ENG-19102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ