### PR TITLE
[ENG-19113] fix typo

### DIFF
--- a/pkg/cmd/edge_services/resources/create/create.go
+++ b/pkg/cmd/edge_services/resources/create/create.go
@@ -22,7 +22,7 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 	createCmd := &cobra.Command{
 		Use:           "create <service_id> [flags]",
 		Short:         "Creates a new resource",
-		Long:          `Creates a new resource in an Edge Service based on a given servce_id.`,
+		Long:          `Creates a new resource in an Edge Service based on a given service_id.`,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
**WHAT**
Fix typo '`giver`'

**WHY**
[ENG-19113]

[ENG-19113]: https://aziontech.atlassian.net/browse/ENG-19113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ