### PR TITLE
chore: add active to describe

### DIFF
--- a/pkg/cmd/edge_functions/describe/describe.go
+++ b/pkg/cmd/edge_functions/describe/describe.go
@@ -50,7 +50,7 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 
 			fmt.Fprintf(out, "ID: %d\n", uint64(function.GetId()))
 			fmt.Fprintf(out, "Name: %s\n", function.GetName())
-			fmt.Fprintf(out, "Active %t\n", function.GetActive())
+			fmt.Fprintf(out, "Active: %t\n", function.GetActive())
 			fmt.Fprintf(out, "Language: %s\n", function.GetLanguage())
 			fmt.Fprintf(out, "Reference Count: %d\n", uint64(function.GetReferenceCount()))
 			fmt.Fprintf(out, "Modified at: %s\n", function.GetModified())

--- a/pkg/cmd/edge_functions/describe/describe_test.go
+++ b/pkg/cmd/edge_functions/describe/describe_test.go
@@ -47,6 +47,7 @@ func TestDescribe(t *testing.T) {
 
 		require.Equal(t, `ID: 1337
 Name: SUUPA_FUNCTION
+Active: true
 Language: javascript
 Reference Count: 0
 Modified at: 2022-01-26T12:31:09.865515Z
@@ -77,6 +78,7 @@ JSON Args: {"a":1,"b":2}
 
 		require.Equal(t, `ID: 1337
 Name: SUUPA_FUNCTION
+Active: true
 Language: javascript
 Reference Count: 0
 Modified at: 2022-01-26T12:31:09.865515Z


### PR DESCRIPTION
**WHAT**
Active (true | false) print was missing.