### PR TITLE
fix: use '-' instead of '–' on help

### DIFF
--- a/pkg/cmd/edge_functions/create/create.go
+++ b/pkg/cmd/edge_functions/create/create.go
@@ -32,9 +32,9 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		Example: heredoc.Doc(`
-        $ azioncli edge_functions create -–name myjsfunc -–language javascript –-code ./mycode/function.js  -–active true
-        $ azioncli edge_functions create -–name withargs -–language javascript –-code ./mycode/function.js  --args ./args.json -–active true
-        $ azioncli edge_functions create -–name myluafunc -–language lua –-code ./mycode/function.lua  --initiator-type edge_firewall -–active false
+        $ azioncli edge_functions create --name myjsfunc --language javascript --code ./mycode/function.js  --active true
+        $ azioncli edge_functions create --name withargs --language javascript --code ./mycode/function.js  --args ./args.json --active true
+        $ azioncli edge_functions create --name myluafunc --language lua --code ./mycode/function.lua  --initiator-type edge_firewall --active false
         `),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			request := api.NewCreateRequest()

--- a/pkg/cmd/edge_functions/update/update.go
+++ b/pkg/cmd/edge_functions/update/update.go
@@ -34,9 +34,9 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		Example: heredoc.Doc(`
-        $ azioncli edge_functions update 1234 -–name 'Hello'
-        $ azioncli edge_functions update 4185 -–code ./mycode/function.js -–args ./mycode/myargs.json
-        $ azioncli edge_functions update 9123 -–active false
+        $ azioncli edge_functions update 1234 --name 'Hello'
+        $ azioncli edge_functions update 4185 --code ./mycode/function.js --args ./mycode/myargs.json
+        $ azioncli edge_functions update 9123 --active false
         `),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {


### PR DESCRIPTION
The en dash character '–' is not hyphen '-' :)

The azioncli command options only accept hyphen.

References:
https://www.compart.com/en/unicode/U+2013
https://www.compart.com/en/unicode/U+002D