### PR TITLE
chore: remove lua edge functions related code

### DIFF
--- a/pkg/api/edge_functions/edge_functions.go
+++ b/pkg/api/edge_functions/edge_functions.go
@@ -10,6 +10,8 @@ import (
 	sdk "github.com/aziontech/azionapi-go-sdk/edgefunctions"
 )
 
+const javascript = "javascript"
+
 type Client struct {
 	apiClient *sdk.APIClient
 }
@@ -75,6 +77,10 @@ func NewCreateRequest() *CreateRequest {
 }
 
 func (c *Client) Create(ctx context.Context, req *CreateRequest) (EdgeFunctionResponse, error) {
+	// Altough there's only one option, the API requires the `language` field.
+	// Hard-coding javascript for now
+	req.CreateEdgeFunctionRequest.SetLanguage(javascript)
+
 	request := c.apiClient.EdgeFunctionsApi.EdgeFunctionsPost(ctx).CreateEdgeFunctionRequest(req.CreateEdgeFunctionRequest)
 
 	edgeFuncResponse, httpRes, err := request.Execute()

--- a/pkg/cmd/edge_functions/create/create.go
+++ b/pkg/cmd/edge_functions/create/create.go
@@ -32,9 +32,8 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		Example: heredoc.Doc(`
-        $ azioncli edge_functions create --name myjsfunc --language javascript --code ./mycode/function.js  --active true
-        $ azioncli edge_functions create --name withargs --language javascript --code ./mycode/function.js  --args ./args.json --active true
-        $ azioncli edge_functions create --name myluafunc --language lua --code ./mycode/function.lua  --initiator-type edge_firewall --active false
+        $ azioncli edge_functions create --name myjsfunc --code ./mycode/function.js --active true
+        $ azioncli edge_functions create --name withargs --code ./mycode/function.js --args ./args.json --active true
         `),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			request := api.NewCreateRequest()
@@ -65,7 +64,6 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 			}
 
 			request.SetName(fields.Name)
-			request.SetLanguage(fields.Language)
 
 			if cmd.Flags().Changed("initiator-type") {
 				request.SetInitiatorType(fields.InitiatorType)
@@ -94,14 +92,11 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 	flags := cmd.Flags()
 
 	flags.StringVar(&fields.Name, "name", "", "Name of your Edge Function.")
-	flags.StringVar(&fields.Language, "language", "", "Programming language of your Edge Function <javascript|lua>")
 	flags.StringVar(&fields.Code, "code", "", "Path to the file containing your Edge Function code.")
-	flags.StringVar(&fields.InitiatorType, "initiator-type", "", "Initiator of your Edge Function (only valid for Lua functions): <edge-application|edge-firewall>")
 	flags.StringVar(&fields.Active, "active", "", "Whether or not your Edge Function should be active: <true|false>")
 	flags.StringVar(&fields.Args, "args", "", "Path to the file containing the JSON arguments of your Edge Function")
 
 	_ = cmd.MarkFlagRequired("name")
-	_ = cmd.MarkFlagRequired("language")
 	_ = cmd.MarkFlagRequired("code")
 	_ = cmd.MarkFlagRequired("active")
 

--- a/pkg/cmd/edge_functions/create/create_test.go
+++ b/pkg/cmd/edge_functions/create/create_test.go
@@ -47,7 +47,7 @@ func TestCreate(t *testing.T) {
 		args, _ := os.CreateTemp(t.TempDir(), "args*.json")
 		_, _ = args.WriteString(`{"best_sweet": "dorayaki"}`)
 
-		cmd.SetArgs([]string{"--name", "SUUPA_FUNCTION", "--active", "true", "--args", args.Name(), "--code", code.Name(), "--language", "javascript"})
+		cmd.SetArgs([]string{"--name", "SUUPA_FUNCTION", "--active", "true", "--args", args.Name(), "--code", code.Name()})
 
 		err := cmd.Execute()
 
@@ -69,7 +69,7 @@ func TestCreate(t *testing.T) {
 
 		file, _ := os.CreateTemp(t.TempDir(), "myfunc*.js")
 		t.TempDir()
-		cmd.SetArgs([]string{"--name", "BIRL", "--active", "true", "--initiator-type", "edge_birl", "--code", file.Name(), "--language", "javascript"})
+		cmd.SetArgs([]string{"--name", "BIRL", "--active", "true", "--initiator-type", "edge_birl", "--code", file.Name()})
 
 		err := cmd.Execute()
 


### PR DESCRIPTION
The API does not support (and probably never will) the creation of Lua functions since those are reserved for internal use.

Therefore, it doesn't make sense to keep Lua related flags in the Edge Function commands.