### PR TITLE
fix(cross-build): build arm64 binaries

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,4 +1,5 @@
 darwin/amd64
+darwin/arm64
 freebsd/amd64
 freebsd/arm64
 linux/386 

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ cross-build: ## cross-compile for all platforms/architectures.
 	do\
 		distro=$$(echo $${spec} | cut -d/ -f1);\
 		goarch=$$(echo $${spec} | cut -d/ -f2);\
-		arch=$$(echo $${goarch} | sed 's/386/x86_32/g; s/amd64/x86_64/g; s/arm$$/arm32/g;');\
+		arch=$$(echo $${goarch} | sed 's/386/x86_32/g; s/amd64/x86_64/g;');\
 		mkdir -p dist/$$distro/$$arch;\
 		CGO_ENABLED=0 GOOS=$$distro GOARCH=$$goarch $(GO) build -ldflags "$(LDFLAGS)" -o ./dist/$$distro/$$arch/$(NAME_WITH_VERSION) ./cmd/$(BIN); \
 	done < BUILD


### PR DESCRIPTION
The `sed` command was making sure that we didn't built arm64 binaries :upside_down_face: 