### PR TITLE
fix: check if http response is nil

### DIFF
--- a/pkg/api/edge_functions/edge_functions.go
+++ b/pkg/api/edge_functions/edge_functions.go
@@ -85,6 +85,9 @@ func (c *Client) Create(ctx context.Context, req *CreateRequest) (EdgeFunctionRe
 
 	edgeFuncResponse, httpRes, err := request.Execute()
 	if err != nil {
+		if httpRes == nil {
+			return nil, err
+		}
 		responseBody, _ := ioutil.ReadAll(httpRes.Body)
 		return nil, fmt.Errorf("%w: %s", err, responseBody)
 	}
@@ -106,6 +109,9 @@ func (c *Client) Update(ctx context.Context, req *UpdateRequest) (EdgeFunctionRe
 
 	edgeFuncResponse, httpRes, err := request.Execute()
 	if err != nil {
+		if httpRes == nil {
+			return nil, err
+		}
 		responseBody, _ := ioutil.ReadAll(httpRes.Body)
 		return nil, fmt.Errorf("%w: %s", err, responseBody)
 	}
@@ -114,7 +120,6 @@ func (c *Client) Update(ctx context.Context, req *UpdateRequest) (EdgeFunctionRe
 }
 
 func (c *Client) List(ctx context.Context, opts *contracts.ListOptions) ([]EdgeFunctionResponse, error) {
-
 	resp, httpResp, err := c.apiClient.EdgeFunctionsApi.EdgeFunctionsGet(ctx).
 		OrderBy(opts.OrderBy).
 		Page(opts.Page).
@@ -123,6 +128,9 @@ func (c *Client) List(ctx context.Context, opts *contracts.ListOptions) ([]EdgeF
 		Execute()
 
 	if err != nil {
+		if httpResp == nil {
+			return nil, err
+		}
 		responseBody, _ := ioutil.ReadAll(httpResp.Body)
 		return nil, fmt.Errorf("%w: %s", err, responseBody)
 	}


### PR DESCRIPTION
## What

Check if HTTP responses are not nil before reading them

## Why
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x40 pc=0x707a1d]

goroutine 1 [running]:
github.com/aziontech/azion-cli/pkg/api/edge_functions.(*Client).List(0xc000010140, {0x92a2d0, 0xc000028170}, 0xc00007c910)
        /home/azion/code/azion-cli/pkg/api/edge_functions/edge_functions.go:126 +0x39d
```