### PR TITLE
[ENG-19324] chore: change json_args from map to interface{}

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aziontech/azion-cli
 go 1.17
 
 require (
-	github.com/aziontech/azionapi-go-sdk v0.7.0
+	github.com/aziontech/azionapi-go-sdk v0.8.0
 	github.com/spf13/cobra v1.3.0
 	github.com/spf13/viper v1.10.1
 )

--- a/go.sum
+++ b/go.sum
@@ -62,8 +62,8 @@ github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmV
 github.com/armon/go-metrics v0.3.10/go.mod h1:4O98XIr/9W0sxpJ8UaYkvjk10Iff7SnFrb4QAOwNTFc=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
-github.com/aziontech/azionapi-go-sdk v0.7.0 h1:qwVWwr75dGTeLO/RlFmFb0qVjrGK/miKiyEi4DWz66c=
-github.com/aziontech/azionapi-go-sdk v0.7.0/go.mod h1:2caFKH52viwZI346MWCGDZzU0jGll6udJZZMDJNrWgg=
+github.com/aziontech/azionapi-go-sdk v0.8.0 h1:neDYlkHDydiEkGKuKMq/XwbzDQcrJM5FGdhH4ppZ3L4=
+github.com/aziontech/azionapi-go-sdk v0.8.0/go.mod h1:2caFKH52viwZI346MWCGDZzU0jGll6udJZZMDJNrWgg=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=

--- a/pkg/api/edge_functions/edge_functions.go
+++ b/pkg/api/edge_functions/edge_functions.go
@@ -27,7 +27,7 @@ type EdgeFunctionResponse interface {
 	GetInitiatorType() string
 	GetLastEditor() string
 	GetFunctionToRun() string
-	GetJsonArgs() map[string]interface{}
+	GetJsonArgs() interface{}
 	GetCode() string
 }
 

--- a/pkg/cmd/edge_functions/describe/describe.go
+++ b/pkg/cmd/edge_functions/describe/describe.go
@@ -82,7 +82,7 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 	return cmd
 }
 
-func serializeToJson(data map[string]interface{}) string {
+func serializeToJson(data interface{}) string {
 	// ignoring errors on purpose
 	serialized, _ := json.Marshal(data)
 	return string(serialized)


### PR DESCRIPTION
**WHAT**
We had a problem unmarshalling the `json_args` item, because we were not expecting to receive arrays. Now, `json_args` is changed into an empty interface, so it can receive any type.

**WHY**
[ENG-19324]

[ENG-19324]: https://aziontech.atlassian.net/browse/ENG-19324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ