### PR TITLE
fix: return error when httpresp is nil

### DIFF
--- a/pkg/cmd/edge_services/create/create.go
+++ b/pkg/cmd/edge_services/create/create.go
@@ -91,7 +91,7 @@ func createNewService(client *sdk.APIClient, out io.Writer, request sdk.CreateSe
 
 	resp, httpResp, err := api.NewService(c).CreateServiceRequest(request).Execute()
 	if err != nil {
-		if httpResp != nil && httpResp.StatusCode >= 500 {
+		if httpResp == nil || httpResp.StatusCode >= 500 {
 			return utils.ErrorInternalServerError
 		}
 		body, err := ioutil.ReadAll(httpResp.Body)

--- a/pkg/cmd/edge_services/delete/delete.go
+++ b/pkg/cmd/edge_services/delete/delete.go
@@ -64,7 +64,7 @@ func deleteService(client *sdk.APIClient, out io.Writer, service_id int64, verbo
 	httpResp, err := api.DeleteService(c, service_id).Execute()
 
 	if err != nil {
-		if httpResp != nil && httpResp.StatusCode >= 500 {
+		if httpResp == nil || httpResp.StatusCode >= 500 {
 			return utils.ErrorInternalServerError
 		}
 		body, err := ioutil.ReadAll(httpResp.Body)

--- a/pkg/cmd/edge_services/describe/describe.go
+++ b/pkg/cmd/edge_services/describe/describe.go
@@ -94,7 +94,7 @@ func describeService(client *sdk.APIClient, service_id int64, withVariables bool
 
 	resp, httpResp, err := api.GetService(c, service_id).WithVars(withVariables).Execute()
 	if err != nil {
-		if httpResp != nil && httpResp.StatusCode >= 500 {
+		if httpResp == nil || httpResp.StatusCode >= 500 {
 			return nil, utils.ErrorInternalServerError
 		}
 		body, err := ioutil.ReadAll(httpResp.Body)

--- a/pkg/cmd/edge_services/resources/create/create.go
+++ b/pkg/cmd/edge_services/resources/create/create.go
@@ -143,7 +143,7 @@ func createNewResource(client *sdk.APIClient, out io.Writer, service_id int64, r
 
 	resp, httpResp, err := api.PostResource(c, service_id).CreateResourceRequest(request).Execute()
 	if err != nil {
-		if httpResp != nil && httpResp.StatusCode >= 500 {
+		if httpResp == nil || httpResp.StatusCode >= 500 {
 			return utils.ErrorInternalServerError
 		}
 		body, err := ioutil.ReadAll(httpResp.Body)

--- a/pkg/cmd/edge_services/resources/delete/delete.go
+++ b/pkg/cmd/edge_services/resources/delete/delete.go
@@ -63,7 +63,7 @@ func deleteResource(client *sdk.APIClient, out io.Writer, service_id int64, reso
 
 	httpResp, err := api.DeleteResource(c, service_id, resource_id).Execute()
 	if err != nil {
-		if httpResp != nil && httpResp.StatusCode >= 500 {
+		if httpResp == nil || httpResp.StatusCode >= 500 {
 			return utils.ErrorInternalServerError
 		}
 		body, err := ioutil.ReadAll(httpResp.Body)

--- a/pkg/cmd/edge_services/resources/describe/describe.go
+++ b/pkg/cmd/edge_services/resources/describe/describe.go
@@ -89,7 +89,7 @@ func describeResource(client *sdk.APIClient, out io.Writer, service_id int64, re
 
 	resp, httpResp, err := api.GetResource(c, service_id, resource_id).Execute()
 	if err != nil {
-		if httpResp != nil && httpResp.StatusCode >= 500 {
+		if httpResp == nil || httpResp.StatusCode >= 500 {
 			return nil, utils.ErrorInternalServerError
 		}
 		body, err := ioutil.ReadAll(httpResp.Body)

--- a/pkg/cmd/edge_services/resources/update/update.go
+++ b/pkg/cmd/edge_services/resources/update/update.go
@@ -171,7 +171,7 @@ func updateResource(client *sdk.APIClient, out io.Writer, service_id int64, reso
 
 	resp, httpResp, err := api.PatchServiceResource(c, service_id, resource_id).UpdateResourceRequest(update.UpdateResourceRequest).Execute()
 	if err != nil {
-		if httpResp != nil && httpResp.StatusCode >= 500 {
+		if httpResp == nil || httpResp.StatusCode >= 500 {
 			return utils.ErrorInternalServerError
 		}
 		body, err := ioutil.ReadAll(httpResp.Body)

--- a/pkg/cmd/edge_services/update/update.go
+++ b/pkg/cmd/edge_services/update/update.go
@@ -165,7 +165,7 @@ func updateService(client *sdk.APIClient, out io.Writer, id int64, cmd *cobra.Co
 
 	resp, httpResp, err := api.PatchService(c, id).UpdateServiceRequest(request.UpdateServiceRequest).Execute()
 	if err != nil {
-		if httpResp != nil && httpResp.StatusCode >= 500 {
+		if httpResp == nil || httpResp.StatusCode >= 500 {
 			return utils.ErrorInternalServerError
 		}
 		body, err := ioutil.ReadAll(httpResp.Body)


### PR DESCRIPTION
**WHAT**
Sometimes we were returning `invalid memory address` or `nil pointer dereference`.