### PR TITLE
[ENG-19619] fix: version cmd and flag have the same text

### DIFF
--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -39,7 +39,7 @@ func NewRootCmd(f *cmdutil.Factory) *cobra.Command {
 		rootHelpFunc(f, cmd, args)
 	})
 
-	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Makes azion-cli verbose during the operation")
+	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Makes azioncli verbose during the operation")
 
 	rootCmd.AddCommand(configure.NewCmd(f))
 	rootCmd.AddCommand(version.NewCmd(f))

--- a/pkg/cmd/version/version.go
+++ b/pkg/cmd/version/version.go
@@ -19,7 +19,7 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 			"IsAdditional": "true",
 		},
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Fprintln(f.IOStreams.Out, "Azion version: "+BinVersion)
+			fmt.Fprintln(f.IOStreams.Out, "azioncli version "+BinVersion)
 		},
 	}
 


### PR DESCRIPTION
**WHAT**
- Version cmd and flag have the same text

**WHY**
[ENG-19619]

[ENG-19619]: https://aziontech.atlassian.net/browse/ENG-19619?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ