### PR TITLE
[ENG-19774] chore: remove verbose flag, as it currently does nothing

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ Available Commands:
 Flags:
   -h, --help           help for azioncli
   -t, --token string   Use provided token
-  -v, --verbose        Makes azioncli verbose during the operation
       --version        version for azioncli
 
 Use "azioncli [command] --help" for more information about a command.
@@ -76,7 +75,6 @@ Flags:
 
 Global Flags:
   -t, --token string   Use provided token
-  -v, --verbose        Makes azioncli verbose during the operation
 
 Use "azioncli edge_services [command] --help" for more information about a command.
 ```

--- a/pkg/cmd/edge_services/create/create_test.go
+++ b/pkg/cmd/edge_services/create/create_test.go
@@ -88,7 +88,6 @@ func TestCreate(t *testing.T) {
 		f, _, _ := testutils.NewFactory(mock)
 
 		cmd := NewCmd(f)
-		cmd.PersistentFlags().BoolP("verbose", "v", false, "")
 		cmd.SetArgs([]string{"--name", "BIRL"})
 		cmd.SetIn(&bytes.Buffer{})
 		cmd.SetOut(ioutil.Discard)

--- a/pkg/cmd/edge_services/delete/delete.go
+++ b/pkg/cmd/edge_services/delete/delete.go
@@ -41,12 +41,7 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 				return err
 			}
 
-			verbose, err := cmd.Flags().GetBool("verbose")
-			if err != nil {
-				return err
-			}
-
-			if err := deleteService(client, f.IOStreams.Out, ids[0], verbose); err != nil {
+			if err := deleteService(client, f.IOStreams.Out, ids[0]); err != nil {
 				return err
 			}
 
@@ -56,7 +51,7 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 	return deleteCmd
 }
 
-func deleteService(client *sdk.APIClient, out io.Writer, service_id int64, verbose bool) error {
+func deleteService(client *sdk.APIClient, out io.Writer, service_id int64) error {
 
 	c := context.Background()
 	api := client.DefaultApi
@@ -75,10 +70,8 @@ func deleteService(client *sdk.APIClient, out io.Writer, service_id int64, verbo
 		return fmt.Errorf("%w: %s", errmsg.ErrorDeleteService, string(body))
 	}
 
-	if verbose {
-		if httpResp.StatusCode == 204 {
-			fmt.Fprintf(out, "Service %d was successfully deleted\n", service_id)
-		}
+	if httpResp.StatusCode == 204 {
+		fmt.Fprintf(out, "Service %d was successfully deleted\n", service_id)
 	}
 
 	return nil

--- a/pkg/cmd/edge_services/delete/delete_test.go
+++ b/pkg/cmd/edge_services/delete/delete_test.go
@@ -23,7 +23,6 @@ func TestCreate(t *testing.T) {
 		f, stdout, _ := testutils.NewFactory(mock)
 
 		cmd := NewCmd(f)
-		cmd.PersistentFlags().BoolP("verbose", "v", false, "")
 		cmd.SetArgs([]string{"1234"})
 		cmd.SetIn(&bytes.Buffer{})
 		cmd.SetOut(ioutil.Discard)
@@ -32,30 +31,8 @@ func TestCreate(t *testing.T) {
 		_, err := cmd.ExecuteC()
 		require.NoError(t, err)
 
-		assert.Equal(t, "", stdout.String())
-	})
-
-	t.Run("delete service by id being verbose", func(t *testing.T) {
-		mock := &httpmock.Registry{}
-
-		mock.Register(
-			httpmock.REST("DELETE", "edge_services/1234"),
-			httpmock.StatusStringResponse(204, ""),
-		)
-
-		f, stdout, _ := testutils.NewFactory(mock)
-
-		cmd := NewCmd(f)
-		cmd.PersistentFlags().BoolP("verbose", "v", false, "")
-		cmd.SetArgs([]string{"1234", "-v"})
-		cmd.SetIn(&bytes.Buffer{})
-		cmd.SetOut(ioutil.Discard)
-		cmd.SetErr(ioutil.Discard)
-
-		_, err := cmd.ExecuteC()
-		require.NoError(t, err)
-
-		assert.Equal(t, "Service 1234 was successfully deleted\n", stdout.String())
+		assert.Equal(t, `Service 1234 was successfully deleted
+`, stdout.String())
 	})
 
 	t.Run("delete service that is not found", func(t *testing.T) {

--- a/pkg/cmd/edge_services/resources/create/create_test.go
+++ b/pkg/cmd/edge_services/resources/create/create_test.go
@@ -64,8 +64,7 @@ func TestCreate(t *testing.T) {
 		_, _ = contentFile.Write([]byte("insert your text here"))
 
 		cmd := NewCmd(f)
-		cmd.PersistentFlags().BoolP("verbose", "v", false, "")
-		cmd.SetArgs([]string{"-v", "1234", "--name", "/tmp/testando.txt", "--content-type", "text", "--content-file", contentFile.Name()})
+		cmd.SetArgs([]string{"1234", "--name", "/tmp/testando.txt", "--content-type", "text", "--content-file", contentFile.Name()})
 		cmd.SetIn(&bytes.Buffer{})
 		cmd.SetOut(ioutil.Discard)
 		cmd.SetErr(ioutil.Discard)
@@ -101,7 +100,6 @@ func TestCreate(t *testing.T) {
 		_, _ = contentFile.Write([]byte("#!/bin/sh"))
 
 		cmd := NewCmd(f)
-		cmd.PersistentFlags().BoolP("verbose", "v", false, "")
 		cmd.SetArgs([]string{"1234", "--name", "/tmp/bomb.sh", "--trigger", "Install", "--content-type", "shellscript", "--content-file", contentFile.Name()})
 		cmd.SetIn(&bytes.Buffer{})
 		cmd.SetOut(ioutil.Discard)
@@ -160,7 +158,6 @@ func TestCreate(t *testing.T) {
 		cmd.SetIn(&bytes.Buffer{})
 		cmd.SetOut(ioutil.Discard)
 		cmd.SetErr(ioutil.Discard)
-		cmd.PersistentFlags().BoolP("verbose", "v", false, "")
 		_, err := cmd.ExecuteC()
 		require.EqualError(t, err, "Failed to create Resource: Not found")
 	})

--- a/pkg/cmd/edge_services/resources/delete/delete.go
+++ b/pkg/cmd/edge_services/resources/delete/delete.go
@@ -41,12 +41,7 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 				return err
 			}
 
-			verbose, err := cmd.Flags().GetBool("verbose")
-			if err != nil {
-				return err
-			}
-
-			if err := deleteResource(client, f.IOStreams.Out, ids[0], ids[1], verbose); err != nil {
+			if err := deleteResource(client, f.IOStreams.Out, ids[0], ids[1]); err != nil {
 				return err
 			}
 
@@ -56,7 +51,7 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 	return deleteCmd
 }
 
-func deleteResource(client *sdk.APIClient, out io.Writer, service_id int64, resource_id int64, verbose bool) error {
+func deleteResource(client *sdk.APIClient, out io.Writer, service_id int64, resource_id int64) error {
 
 	c := context.Background()
 	api := client.DefaultApi
@@ -74,10 +69,8 @@ func deleteResource(client *sdk.APIClient, out io.Writer, service_id int64, reso
 		return fmt.Errorf("%w: %s", errmsg.ErrorDeleteResource, string(body))
 	}
 
-	if verbose {
-		if httpResp.StatusCode == 204 {
-			fmt.Fprintf(out, "Resource %d was successfully deleted\n", resource_id)
-		}
+	if httpResp.StatusCode == 204 {
+		fmt.Fprintf(out, "Resource %d was successfully deleted\n", resource_id)
 	}
 
 	return nil

--- a/pkg/cmd/edge_services/resources/delete/delete_test.go
+++ b/pkg/cmd/edge_services/resources/delete/delete_test.go
@@ -23,7 +23,6 @@ func TestCreate(t *testing.T) {
 		f, stdout, _ := testutils.NewFactory(mock)
 
 		cmd := NewCmd(f)
-		cmd.PersistentFlags().BoolP("verbose", "v", false, "")
 		cmd.SetArgs([]string{"1234", "456"})
 		cmd.SetIn(&bytes.Buffer{})
 		cmd.SetOut(ioutil.Discard)
@@ -32,30 +31,8 @@ func TestCreate(t *testing.T) {
 		_, err := cmd.ExecuteC()
 		require.NoError(t, err)
 
-		assert.Equal(t, "", stdout.String())
-	})
-
-	t.Run("delete resource by id being verbose", func(t *testing.T) {
-		mock := &httpmock.Registry{}
-
-		mock.Register(
-			httpmock.REST("DELETE", "edge_services/1234/resources/456"),
-			httpmock.StatusStringResponse(204, ""),
-		)
-
-		f, stdout, _ := testutils.NewFactory(mock)
-
-		cmd := NewCmd(f)
-		cmd.PersistentFlags().BoolP("verbose", "v", false, "")
-		cmd.SetArgs([]string{"1234", "456", "-v"})
-		cmd.SetIn(&bytes.Buffer{})
-		cmd.SetOut(ioutil.Discard)
-		cmd.SetErr(ioutil.Discard)
-
-		_, err := cmd.ExecuteC()
-		require.NoError(t, err)
-
-		assert.Equal(t, "Resource 456 was successfully deleted\n", stdout.String())
+		assert.Equal(t, `Resource 456 was successfully deleted
+`, stdout.String())
 	})
 
 	t.Run("delete missing resource", func(t *testing.T) {

--- a/pkg/cmd/edge_services/resources/update/update_test.go
+++ b/pkg/cmd/edge_services/resources/update/update_test.go
@@ -96,7 +96,6 @@ func TestUpdate(t *testing.T) {
 		f, _, _ := testutils.NewFactory(mock)
 
 		cmd := NewCmd(f)
-		cmd.PersistentFlags().BoolP("verbose", "v", false, "")
 		cmd.SetArgs([]string{"1234", "666", "--name", "BIRL"})
 		cmd.SetIn(&bytes.Buffer{})
 		cmd.SetOut(ioutil.Discard)
@@ -136,7 +135,6 @@ func TestUpdate(t *testing.T) {
 		_, _ = contentFile.Write([]byte("This content is made for testing purposes"))
 
 		cmd := NewCmd(f)
-		cmd.PersistentFlags().BoolP("verbose", "v", false, "")
 		cmd.SetArgs([]string{"1234", "666", "--name", "BIRL", "--trigger", "Install", "--content-type", "shellscript", "--content-file", contentFile.Name()})
 		cmd.SetIn(&bytes.Buffer{})
 		cmd.SetOut(ioutil.Discard)

--- a/pkg/cmd/edge_services/update/update_test.go
+++ b/pkg/cmd/edge_services/update/update_test.go
@@ -54,7 +54,6 @@ func TestUpdate(t *testing.T) {
 		f, _, _ := testutils.NewFactory(mock)
 
 		cmd := NewCmd(f)
-		cmd.PersistentFlags().BoolP("verbose", "v", false, "")
 		cmd.SetArgs([]string{"1234", "--name", "thunderstruck"})
 		cmd.SetIn(&bytes.Buffer{})
 		cmd.SetOut(ioutil.Discard)

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -39,8 +39,6 @@ func NewRootCmd(f *cmdutil.Factory) *cobra.Command {
 		rootHelpFunc(f, cmd, args)
 	})
 
-	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Makes azioncli verbose during the operation")
-
 	rootCmd.AddCommand(configure.NewCmd(f))
 	rootCmd.AddCommand(version.NewCmd(f))
 	rootCmd.AddCommand(edge_services.NewCmd(f))


### PR DESCRIPTION
**WHAT**
`Verbose` flag currently does nothing. 
We need to define what will be shown when using such flag. For now, we decided to just remove it from the code and we will reimplement it when we have a clear definition of its use.

**WHY**
[ENG-19774]

[ENG-19774]: https://aziontech.atlassian.net/browse/ENG-19774?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ