### PR TITLE
fix: remove .md suffix from doc links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 #Directories
 bin/
 dist/
+docs/
 .vscode/
 
 #Files

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,10 @@ test:
 	@$(GO) tool cover -func "./cover/$(NAME)coverage.out"
 	@echo Done
 
+.PHONY: docs
+docs:
+	$(GO) run ./cmd/gen_docs/main.go --doc-path ./docs --file-type md
+
 .PHONY: sec
 sec: get-gosec-deps ## running GoSec
 	@ -$(GOSEC) ./...

--- a/cmd/gen_docs/main.go
+++ b/cmd/gen_docs/main.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	cmd "github.com/aziontech/azion-cli/pkg/cmd/root"
@@ -67,7 +68,11 @@ func run(args []string) error {
 		if err := os.MkdirAll(*dir, 0755); err != nil {
 			return err
 		}
-		err := doc.GenMarkdownTree(rootCmd, *dir)
+
+		removeMdSuffix := func(s string) string { return strings.TrimRight(s, ".md") }
+		dontPreprendFile := func(s string) string { return "" }
+
+		err := doc.GenMarkdownTreeCustom(rootCmd, *dir, dontPreprendFile, removeMdSuffix)
 		if err != nil {
 			log.Fatal(err)
 		}


### PR DESCRIPTION
## What

- Remove `.md` suffix, this should fix our issues with links on the Wiki
- Add `docs` target to Makefile
