### PR TITLE
chore: change factory to return http client directly

### DIFF
--- a/cmd/gen_docs/main.go
+++ b/cmd/gen_docs/main.go
@@ -4,11 +4,9 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
 	cmd "github.com/aziontech/azion-cli/pkg/cmd/root"
 	"github.com/aziontech/azion-cli/pkg/cmdutil"
@@ -43,16 +41,9 @@ func run(args []string) error {
 		return fmt.Errorf("error: --doc-path not set")
 	}
 
-	factory := &cmdutil.Factory{
-		HttpClient: func() (*http.Client, error) {
-			return &http.Client{
-				Timeout: 10 * time.Second,
-			}, nil
-		},
+	rootCmd := cmd.NewRootCmd(&cmdutil.Factory{
 		IOStreams: iostreams.System(),
-	}
-
-	rootCmd := cmd.NewRootCmd(factory)
+	})
 	rootCmd.InitDefaultHelpCmd()
 
 	switch {

--- a/pkg/cmd/configure/configure.go
+++ b/pkg/cmd/configure/configure.go
@@ -21,13 +21,8 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 			"IsAdditional": "true",
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			client, err := f.HttpClient()
-			if err != nil {
-				return fmt.Errorf("%s: %w", utils.ErrorGetHttpClient, err)
-			}
-
 			t, err := token.New(&token.Config{
-				Client: client,
+				Client: f.HttpClient,
 				Out:    f.IOStreams.Out,
 			})
 			if err != nil {

--- a/pkg/cmd/edge_functions/create/create.go
+++ b/pkg/cmd/edge_functions/create/create.go
@@ -97,12 +97,7 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 				}
 			}
 
-			httpClient, err := f.HttpClient()
-			if err != nil {
-				return fmt.Errorf("%s: %w", utils.ErrorGetHttpClient, err)
-			}
-
-			client := api.NewClient(httpClient, f.Config.GetString("api_url"), f.Config.GetString("token"))
+			client := api.NewClient(f.HttpClient, f.Config.GetString("api_url"), f.Config.GetString("token"))
 
 			ctx := context.Background()
 			response, err := client.Create(ctx, request)

--- a/pkg/cmd/edge_functions/delete/delete.go
+++ b/pkg/cmd/edge_functions/delete/delete.go
@@ -32,11 +32,7 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 				return utils.ErrorConvertingIdArgumentToInt
 			}
 
-			httpClient, err := f.HttpClient()
-			if err != nil {
-				return fmt.Errorf("%s: %w", utils.ErrorGetHttpClient, err)
-			}
-			client := api.NewClient(httpClient, f.Config.GetString("api_url"), f.Config.GetString("token"))
+			client := api.NewClient(f.HttpClient, f.Config.GetString("api_url"), f.Config.GetString("token"))
 
 			ctx := context.Background()
 

--- a/pkg/cmd/edge_functions/describe/describe.go
+++ b/pkg/cmd/edge_functions/describe/describe.go
@@ -40,12 +40,7 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 				return utils.ErrorConvertingIdArgumentToInt
 			}
 
-			httpClient, err := f.HttpClient()
-			if err != nil {
-				return fmt.Errorf("%s: %w", utils.ErrorGetHttpClient, err)
-			}
-
-			client := api.NewClient(httpClient, f.Config.GetString("api_url"), f.Config.GetString("token"))
+			client := api.NewClient(f.HttpClient, f.Config.GetString("api_url"), f.Config.GetString("token"))
 
 			ctx := context.Background()
 			function, err := client.Get(ctx, ids[0])

--- a/pkg/cmd/edge_functions/list/list.go
+++ b/pkg/cmd/edge_functions/list/list.go
@@ -2,7 +2,6 @@ package list
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/MakeNowJust/heredoc"
 	api "github.com/aziontech/azion-cli/pkg/api/edge_functions"
@@ -10,7 +9,6 @@ import (
 	"github.com/aziontech/azion-cli/pkg/cmdutil"
 	"github.com/aziontech/azion-cli/pkg/contracts"
 	"github.com/aziontech/azion-cli/pkg/printer"
-	"github.com/aziontech/azion-cli/utils"
 	"github.com/spf13/cobra"
 )
 
@@ -27,11 +25,7 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
         $ azioncli edge_functions list [--details]
         `),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			httpClient, err := f.HttpClient()
-			if err != nil {
-				return fmt.Errorf("%s: %w", utils.ErrorGetHttpClient, err)
-			}
-			client := api.NewClient(httpClient, f.Config.GetString("api_url"), f.Config.GetString("token"))
+			client := api.NewClient(f.HttpClient, f.Config.GetString("api_url"), f.Config.GetString("token"))
 			ctx := context.Background()
 
 			fields := []string{"GetId()", "GetName()", "GetLanguage()", "GetActive()"}

--- a/pkg/cmd/edge_functions/update/update.go
+++ b/pkg/cmd/edge_functions/update/update.go
@@ -107,12 +107,7 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 				}
 			}
 
-			httpClient, err := f.HttpClient()
-			if err != nil {
-				return fmt.Errorf("%s: %w", utils.ErrorGetHttpClient, err)
-			}
-
-			client := api.NewClient(httpClient, f.Config.GetString("api_url"), f.Config.GetString("token"))
+			client := api.NewClient(f.HttpClient, f.Config.GetString("api_url"), f.Config.GetString("token"))
 
 			ctx := context.Background()
 			response, err := client.Update(ctx, &request)

--- a/pkg/cmd/edge_services/requests/request.go
+++ b/pkg/cmd/edge_services/requests/request.go
@@ -1,22 +1,14 @@
 package requests
 
 import (
-	"fmt"
-
 	"github.com/aziontech/azion-cli/pkg/cmd/version"
 	"github.com/aziontech/azion-cli/pkg/cmdutil"
-	"github.com/aziontech/azion-cli/utils"
 	sdk "github.com/aziontech/azionapi-go-sdk/edgeservices"
 )
 
 func CreateClient(f *cmdutil.Factory) (*sdk.APIClient, error) {
-	httpClient, err := f.HttpClient()
-	if err != nil {
-		return nil, fmt.Errorf("%s: %w", utils.ErrorGetHttpClient, err)
-	}
-
 	conf := sdk.NewConfiguration()
-	conf.HTTPClient = httpClient
+	conf.HTTPClient = f.HttpClient
 	conf.AddDefaultHeader("Authorization", "token "+f.Config.GetString("token"))
 	conf.UserAgent = "Azion_CLI/" + version.BinVersion
 	conf.Servers = sdk.ServerConfigurations{

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -61,11 +61,9 @@ func Execute() {
 	viper.SetDefault("api_url", constants.ApiURL)
 
 	factory := &cmdutil.Factory{
-		HttpClient: func() (*http.Client, error) {
-			return httpClient, nil
-		},
-		IOStreams: streams,
-		Config:    viper.GetViper(),
+		HttpClient: httpClient,
+		IOStreams:  streams,
+		Config:     viper.GetViper(),
 	}
 
 	cmd := NewRootCmd(factory)

--- a/pkg/cmdutil/factory.go
+++ b/pkg/cmdutil/factory.go
@@ -8,7 +8,7 @@ import (
 )
 
 type Factory struct {
-	HttpClient func() (*http.Client, error)
+	HttpClient *http.Client
 	IOStreams  *iostreams.IOStreams
 	Config     config.Config
 }

--- a/pkg/testutils/testutils.go
+++ b/pkg/testutils/testutils.go
@@ -13,9 +13,7 @@ import (
 func NewFactory(mock *httpmock.Registry) (factory *cmdutil.Factory, out *bytes.Buffer, err *bytes.Buffer) {
 	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
 	f := &cmdutil.Factory{
-		HttpClient: func() (*http.Client, error) {
-			return &http.Client{Transport: mock}, nil
-		},
+		HttpClient: &http.Client{Transport: mock},
 		IOStreams: &iostreams.IOStreams{
 			Out: stdout,
 			Err: stderr,

--- a/utils/errors.go
+++ b/utils/errors.go
@@ -13,7 +13,6 @@ var (
 	ErrorInternalServerError        = errors.New("Something went wrong, please try again")
 	ErrorUpdateNoFlagsSent          = errors.New("You must provide at least one value in update. Use -h or --help for more information")
 	ErrorUnmarshalReader            = errors.New("Failed to unmarshal from reader")
-	ErrorGetHttpClient              = errors.New("Failed to get http client")
 	ErrorFormatOut                  = errors.New("Failed to format response")
 	ErrorWriteFile                  = errors.New("Failed to write to file")
 	ErrorTokenManager               = errors.New("Failed to create token manager")


### PR DESCRIPTION
## What
Change the `cmdutils.Factory` to have the HttpClient as a property instead of a method that could return an error.

## Why
We don't really needed the extra complexity since we didn't have a single use case for returning an error.

It goes to show that we can't just do what other projects do blindly. 