### PR TITLE
chore: get working directory for operations

### DIFF
--- a/pkg/cmd/init/options.go
+++ b/pkg/cmd/init/options.go
@@ -5,7 +5,7 @@ import (
 	"os"
 )
 
-type TestFunc func() error
+type TestFunc func(path string) error
 
 var testFuncByType = map[string]TestFunc{
 	"javascript": testJs,
@@ -13,8 +13,8 @@ var testFuncByType = map[string]TestFunc{
 	"flareact":   nil,
 }
 
-func testJs() error {
-	if _, err := os.Stat("./package.json"); errors.Is(err, os.ErrNotExist) {
+func testJs(path string) error {
+	if _, err := os.Stat(path + "/package.json"); errors.Is(err, os.ErrNotExist) {
 		return ErrorPackageJsonNotFound
 	}
 	return nil

--- a/pkg/contracts/contracts.go
+++ b/pkg/contracts/contracts.go
@@ -15,12 +15,12 @@ type DescribeOptions struct {
 }
 
 type AzionApplicationOptions struct {
-	Test         func() error `json:"-"`
-	Name         string       `json:"name"`
-	Language     string       `json:"language"`
-	Env          string       `json:"env"`
-	FunctionFile string       `json:"function_file"`
-	CacheData    cacheConf    `json:"cache"`
+	Test         func(path string) error `json:"-"`
+	Name         string                  `json:"name"`
+	Language     string                  `json:"language"`
+	Env          string                  `json:"env"`
+	FunctionFile string                  `json:"function_file"`
+	CacheData    cacheConf               `json:"cache"`
 }
 
 type AzionApplicationConfig struct {

--- a/utils/helpers.go
+++ b/utils/helpers.go
@@ -47,3 +47,11 @@ func IsDirEmpty(dir string) (bool, error) {
 	}
 	return false, err
 }
+
+func GetWorkingDir() (string, error) {
+	pathWorkingDir, err := os.Getwd()
+	if err != nil {
+		return "", ErrorInternalServerError
+	}
+	return pathWorkingDir, nil
+}


### PR DESCRIPTION
**WHAT**

Get working directory for operations instead of using fixed "./" 
The previous method meant that the CLI binary should be in the same directory as the working directory, which in the future might not be the case.

**WHY**
[NO ISSUE]