### PR TITLE
feat: do not execute empty command

### DIFF
--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -13,7 +13,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type command struct {
+type buildCmd struct {
 	io *iostreams.IOStreams
 	// Return output, exit code and any errors
 	commandRunner      func(cmd string, envvars []string) (string, int, error)
@@ -24,7 +24,7 @@ type command struct {
 }
 
 func NewCmd(f *cmdutil.Factory) *cobra.Command {
-	command := newCommand(f)
+	command := newBuildCmd(f)
 	cobraCmd := &cobra.Command{
 		Use:           "build [flags]",
 		Short:         "Build your Web application",
@@ -44,8 +44,8 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 	return cobraCmd
 }
 
-func newCommand(f *cmdutil.Factory) *command {
-	return &command{
+func newBuildCmd(f *cmdutil.Factory) *buildCmd {
+	return &buildCmd{
 		io:         f.IOStreams,
 		fileReader: os.ReadFile,
 		commandRunner: func(cmd string, envs []string) (string, int, error) {
@@ -57,7 +57,7 @@ func newCommand(f *cmdutil.Factory) *command {
 	}
 }
 
-func (c *command) readConfig() (*contracts.AzionApplicationConfig, error) {
+func (c *buildCmd) readConfig() (*contracts.AzionApplicationConfig, error) {
 	path, err := c.getWorkDir()
 	if err != nil {
 		return nil, err
@@ -77,7 +77,7 @@ func (c *command) readConfig() (*contracts.AzionApplicationConfig, error) {
 	return conf, nil
 }
 
-func (c *command) run() error {
+func (c *buildCmd) run() error {
 	conf, err := c.readConfig()
 	if err != nil {
 		return err
@@ -86,6 +86,10 @@ func (c *command) run() error {
 	envs, err := c.envLoader(conf.BuildData.Env)
 	if err != nil {
 		return ErrReadEnvFile
+	}
+
+	if conf.BuildData.Cmd == "" {
+		return nil
 	}
 
 	fmt.Fprintf(c.io.Out, "Running build command\n\n")

--- a/pkg/cmd/build/build_test.go
+++ b/pkg/cmd/build/build_test.go
@@ -26,7 +26,7 @@ func TestBuild(t *testing.T) {
 
 		envVars := []string{"VAR1=PAODEBATATA", "VAR2=PAODEQUEIJO"}
 
-		command := newCommand(f)
+		command := newBuildCmd(f)
 
 		command.fileReader = func(path string) ([]byte, error) {
 			return jsonContent.Bytes(), nil
@@ -70,7 +70,7 @@ Command exited with code 0
 		envVars := []string{"VAR1=PAODEBATATA", "VAR2=PAODEQUEIJO"}
 		expectedErr := errors.New("invalid file")
 
-		command := newCommand(f)
+		command := newBuildCmd(f)
 
 		command.fileReader = func(path string) ([]byte, error) {
 			return jsonContent.Bytes(), nil
@@ -94,10 +94,24 @@ Command exited with code 42
 `, stdout.String())
 	})
 
+	t.Run("no build.cmd to execute", func(t *testing.T) {
+		f, stdout, _ := testutils.NewFactory(nil)
+
+		command := newBuildCmd(f)
+
+		command.fileReader = func(path string) ([]byte, error) {
+			return []byte(`{"build": {}}`), nil
+		}
+
+		err := command.run()
+		require.NoError(t, err)
+		require.NotContains(t, stdout.String(), "Running build command")
+	})
+
 	t.Run("missing config file", func(t *testing.T) {
 		f, _, _ := testutils.NewFactory(nil)
 
-		command := newCommand(f)
+		command := newBuildCmd(f)
 
 		command.fileReader = func(path string) ([]byte, error) {
 			return nil, os.ErrNotExist
@@ -118,7 +132,7 @@ Command exited with code 42
         }
         `)
 
-		command := newCommand(f)
+		command := newBuildCmd(f)
 
 		command.fileReader = func(path string) ([]byte, error) {
 			return jsonContent.Bytes(), nil
@@ -139,7 +153,7 @@ Command exited with code 42
         }
         `)
 
-		command := newCommand(f)
+		command := newBuildCmd(f)
 
 		command.fileReader = func(path string) ([]byte, error) {
 			return jsonContent.Bytes(), nil

--- a/pkg/cmd/init/init.go
+++ b/pkg/cmd/init/init.go
@@ -215,6 +215,10 @@ func (cmd *initCmd) runInitCmdLine() error {
 		return ErrorUnmarshalConfigFile
 	}
 
+	if conf.InitData.Cmd == "" {
+		return nil
+	}
+
 	envs, err := cmd.envLoader(conf.InitData.Env)
 	if err != nil {
 		return err

--- a/pkg/cmd/init/init_test.go
+++ b/pkg/cmd/init/init_test.go
@@ -310,7 +310,20 @@ func TestInitCmd(t *testing.T) {
 		require.Contains(t, stdout.String(), "my command output")
 	})
 
-	t.Run("runInitCmdLine full", func(t *testing.T) {
+	t.Run("no init.cmd", func(t *testing.T) {
+		f, stdout, _ := testutils.NewFactory(nil)
+
+		cmd := newInitCmd(f)
+		cmd.fileReader = func(path string) ([]byte, error) {
+			return []byte(`{"init": {}}`), nil
+		}
+
+		err := cmd.runInitCmdLine()
+		require.NoError(t, err)
+		require.NotContains(t, stdout.String(), "Running init command")
+	})
+
+	t.Run("full", func(t *testing.T) {
 		f, stdout, _ := testutils.NewFactory(nil)
 
 		envs := []string{"UEBA=OBA", "FAZER=UM_PENSO"}
@@ -333,6 +346,7 @@ func TestInitCmd(t *testing.T) {
 
 		require.NoError(t, err)
 		require.Contains(t, stdout.String(), "my command output")
+		require.Contains(t, stdout.String(), "Running init command")
 
 	})
 }


### PR DESCRIPTION
## What

- Do not output/execute an empty command. This could be helpful in case there's no `init.cmd` specified.
- Rename build command struct to match the init naming