### PR TITLE
[ENG-20529] chore: invert order of messages in rootcmd help

### DIFF
--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -23,8 +23,9 @@ func NewRootCmd(f *cmdutil.Factory) *cobra.Command {
 	rootCmd := &cobra.Command{
 		Use:   "azioncli",
 		Short: "Azion-CLI",
-		Long: `Azion CLI is currently in Beta. We’d love to hear your feedback at https://forms.gle/uBBkyXZCVcrgpvAB8.
-Interact easily with Azion services`,
+		Long: `Interact easily with Azion services.
+
+Azion CLI is currently in Beta. We’d love to hear your feedback at https://forms.gle/uBBkyXZCVcrgpvAB8`,
 		CompletionOptions: cobra.CompletionOptions{
 			DisableDefaultCmd: true,
 		},


### PR DESCRIPTION
**WHAT**
Invert order of messages in root command.

**WHY**
[ENG-20529]

[ENG-20529]: https://aziontech.atlassian.net/browse/ENG-20529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ