### PR TITLE
[ENG-19924] chore: remove initiator_type from create command/struct

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aziontech/azion-cli
 go 1.17
 
 require (
-	github.com/aziontech/azionapi-go-sdk v0.18.0
+	github.com/aziontech/azionapi-go-sdk v0.19.0
 	github.com/spf13/cobra v1.3.0
 	github.com/spf13/viper v1.10.1
 )

--- a/go.sum
+++ b/go.sum
@@ -62,8 +62,8 @@ github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmV
 github.com/armon/go-metrics v0.3.10/go.mod h1:4O98XIr/9W0sxpJ8UaYkvjk10Iff7SnFrb4QAOwNTFc=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
-github.com/aziontech/azionapi-go-sdk v0.18.0 h1:FdueAbQpPHSEiC89CXktZpGxUcOpz1XGWFdeK+P0dKw=
-github.com/aziontech/azionapi-go-sdk v0.18.0/go.mod h1:2caFKH52viwZI346MWCGDZzU0jGll6udJZZMDJNrWgg=
+github.com/aziontech/azionapi-go-sdk v0.19.0 h1:ihXTO1/70DbDvhsPvYM2/FwjB/rjvvbCtZNVJXDFGUE=
+github.com/aziontech/azionapi-go-sdk v0.19.0/go.mod h1:2caFKH52viwZI346MWCGDZzU0jGll6udJZZMDJNrWgg=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=

--- a/pkg/cmd/edge_functions/create/create.go
+++ b/pkg/cmd/edge_functions/create/create.go
@@ -92,9 +92,6 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 
 				request.SetName(fields.Name)
 
-				if cmd.Flags().Changed("initiator-type") {
-					request.SetInitiatorType(fields.InitiatorType)
-				}
 			}
 
 			client := api.NewClient(f.HttpClient, f.Config.GetString("api_url"), f.Config.GetString("token"))


### PR DESCRIPTION
**WHAT**
Remove `initiator_type` from go structure and stop adding it to create request.

**WHY**
[ENG-19924]

[ENG-19924]: https://aziontech.atlassian.net/browse/ENG-19924?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ