### PR TITLE
[ENG-20839] chore: in case of timeout, we provide a clarifying message

### DIFF
--- a/pkg/api/domains/domains.go
+++ b/pkg/api/domains/domains.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"time"
 
 	"github.com/aziontech/azion-cli/pkg/cmd/version"
 	sdk "github.com/aziontech/azionapi-go-sdk/domains"
@@ -37,6 +38,7 @@ func NewClient(c *http.Client, url string, token string) *Client {
 	conf.Servers = sdk.ServerConfigurations{
 		{URL: url},
 	}
+	conf.HTTPClient.Timeout = 5 * time.Second
 
 	return &Client{
 		apiClient: sdk.NewAPIClient(conf),

--- a/pkg/api/domains/domains.go
+++ b/pkg/api/domains/domains.go
@@ -38,7 +38,7 @@ func NewClient(c *http.Client, url string, token string) *Client {
 	conf.Servers = sdk.ServerConfigurations{
 		{URL: url},
 	}
-	conf.HTTPClient.Timeout = 5 * time.Second
+	conf.HTTPClient.Timeout = 10 * time.Second
 
 	return &Client{
 		apiClient: sdk.NewAPIClient(conf),

--- a/pkg/api/edge_applications/edge_applications.go
+++ b/pkg/api/edge_applications/edge_applications.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"time"
 
 	"github.com/aziontech/azion-cli/pkg/cmd/version"
 	sdk "github.com/aziontech/azionapi-go-sdk/edgeapplications"
@@ -54,6 +55,7 @@ func NewClient(c *http.Client, url string, token string) *Client {
 	conf.Servers = sdk.ServerConfigurations{
 		{URL: url},
 	}
+	conf.HTTPClient.Timeout = 10 * time.Second
 
 	return &Client{
 		apiClient: sdk.NewAPIClient(conf),

--- a/pkg/api/edge_functions/edge_functions.go
+++ b/pkg/api/edge_functions/edge_functions.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"time"
 
 	"github.com/aziontech/azion-cli/pkg/cmd/version"
 	"github.com/aziontech/azion-cli/pkg/contracts"
@@ -40,6 +41,7 @@ func NewClient(c *http.Client, url string, token string) *Client {
 	conf.Servers = sdk.ServerConfigurations{
 		{URL: url},
 	}
+	conf.HTTPClient.Timeout = 10 * time.Second
 
 	return &Client{
 		apiClient: sdk.NewAPIClient(conf),

--- a/pkg/api/realtime_purge/realtime_purge.go
+++ b/pkg/api/realtime_purge/realtime_purge.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"time"
 
 	"github.com/aziontech/azion-cli/pkg/cmd/version"
 	sdk "github.com/aziontech/azionapi-go-sdk/realtimepurge"
@@ -23,6 +24,7 @@ func NewClient(c *http.Client, url string, token string) *Client {
 	conf.Servers = sdk.ServerConfigurations{
 		{URL: url},
 	}
+	conf.HTTPClient.Timeout = 10 * time.Second
 
 	return &Client{
 		apiClient: sdk.NewAPIClient(conf),

--- a/pkg/cmd/edge_services/create/create.go
+++ b/pkg/cmd/edge_services/create/create.go
@@ -92,7 +92,8 @@ func createNewService(client *sdk.APIClient, out io.Writer, request sdk.CreateSe
 	resp, httpResp, err := api.NewService(c).CreateServiceRequest(request).Execute()
 	if err != nil {
 		if httpResp == nil || httpResp.StatusCode >= 500 {
-			return utils.ErrorInternalServerError
+			err := utils.CheckStatusCode500Error(err)
+			return err
 		}
 		body, err := ioutil.ReadAll(httpResp.Body)
 		if err != nil {

--- a/pkg/cmd/edge_services/delete/delete.go
+++ b/pkg/cmd/edge_services/delete/delete.go
@@ -60,7 +60,8 @@ func deleteService(client *sdk.APIClient, out io.Writer, service_id int64) error
 
 	if err != nil {
 		if httpResp == nil || httpResp.StatusCode >= 500 {
-			return utils.ErrorInternalServerError
+			err := utils.CheckStatusCode500Error(err)
+			return err
 		}
 		body, err := ioutil.ReadAll(httpResp.Body)
 		if err != nil {

--- a/pkg/cmd/edge_services/describe/describe.go
+++ b/pkg/cmd/edge_services/describe/describe.go
@@ -95,7 +95,8 @@ func describeService(client *sdk.APIClient, service_id int64, withVariables bool
 	resp, httpResp, err := api.GetService(c, service_id).WithVars(withVariables).Execute()
 	if err != nil {
 		if httpResp == nil || httpResp.StatusCode >= 500 {
-			return nil, utils.ErrorInternalServerError
+			err := utils.CheckStatusCode500Error(err)
+			return nil, err
 		}
 		body, err := ioutil.ReadAll(httpResp.Body)
 		if err != nil {

--- a/pkg/cmd/edge_services/list/list.go
+++ b/pkg/cmd/edge_services/list/list.go
@@ -65,7 +65,8 @@ func listAllServices(client *sdk.APIClient, out io.Writer, opts *contracts.ListO
 
 	if err != nil {
 		if httpResp == nil || httpResp.StatusCode >= 500 {
-			return utils.ErrorInternalServerError
+			err := utils.CheckStatusCode500Error(err)
+			return err
 		}
 		body, err := ioutil.ReadAll(httpResp.Body)
 		if err != nil {

--- a/pkg/cmd/edge_services/requests/request.go
+++ b/pkg/cmd/edge_services/requests/request.go
@@ -1,6 +1,8 @@
 package requests
 
 import (
+	"time"
+
 	"github.com/aziontech/azion-cli/pkg/cmd/version"
 	"github.com/aziontech/azion-cli/pkg/cmdutil"
 	sdk "github.com/aziontech/azionapi-go-sdk/edgeservices"
@@ -16,6 +18,7 @@ func CreateClient(f *cmdutil.Factory) (*sdk.APIClient, error) {
 			URL: f.Config.GetString("api_url"),
 		},
 	}
+	conf.HTTPClient.Timeout = 10 * time.Second
 
 	return sdk.NewAPIClient(conf), nil
 }

--- a/pkg/cmd/edge_services/resources/create/create.go
+++ b/pkg/cmd/edge_services/resources/create/create.go
@@ -144,7 +144,8 @@ func createNewResource(client *sdk.APIClient, out io.Writer, service_id int64, r
 	resp, httpResp, err := api.PostResource(c, service_id).CreateResourceRequest(request).Execute()
 	if err != nil {
 		if httpResp == nil || httpResp.StatusCode >= 500 {
-			return utils.ErrorInternalServerError
+			err := utils.CheckStatusCode500Error(err)
+			return err
 		}
 		body, err := ioutil.ReadAll(httpResp.Body)
 		if err != nil {

--- a/pkg/cmd/edge_services/resources/delete/delete.go
+++ b/pkg/cmd/edge_services/resources/delete/delete.go
@@ -59,7 +59,8 @@ func deleteResource(client *sdk.APIClient, out io.Writer, service_id int64, reso
 	httpResp, err := api.DeleteResource(c, service_id, resource_id).Execute()
 	if err != nil {
 		if httpResp == nil || httpResp.StatusCode >= 500 {
-			return utils.ErrorInternalServerError
+			err := utils.CheckStatusCode500Error(err)
+			return err
 		}
 		body, err := ioutil.ReadAll(httpResp.Body)
 		if err != nil {

--- a/pkg/cmd/edge_services/resources/describe/describe.go
+++ b/pkg/cmd/edge_services/resources/describe/describe.go
@@ -90,7 +90,8 @@ func describeResource(client *sdk.APIClient, out io.Writer, service_id int64, re
 	resp, httpResp, err := api.GetResource(c, service_id, resource_id).Execute()
 	if err != nil {
 		if httpResp == nil || httpResp.StatusCode >= 500 {
-			return nil, utils.ErrorInternalServerError
+			err := utils.CheckStatusCode500Error(err)
+			return nil, err
 		}
 		body, err := ioutil.ReadAll(httpResp.Body)
 		if err != nil {

--- a/pkg/cmd/edge_services/resources/list/list.go
+++ b/pkg/cmd/edge_services/resources/list/list.go
@@ -74,7 +74,8 @@ func listAllResources(client *sdk.APIClient, out io.Writer, opts *contracts.List
 
 	if err != nil {
 		if httpResp == nil || httpResp.StatusCode >= 500 {
-			return utils.ErrorInternalServerError
+			err := utils.CheckStatusCode500Error(err)
+			return err
 		}
 		body, err := ioutil.ReadAll(httpResp.Body)
 		if err != nil {

--- a/pkg/cmd/edge_services/resources/update/update.go
+++ b/pkg/cmd/edge_services/resources/update/update.go
@@ -172,7 +172,8 @@ func updateResource(client *sdk.APIClient, out io.Writer, service_id int64, reso
 	resp, httpResp, err := api.PatchServiceResource(c, service_id, resource_id).UpdateResourceRequest(update.UpdateResourceRequest).Execute()
 	if err != nil {
 		if httpResp == nil || httpResp.StatusCode >= 500 {
-			return utils.ErrorInternalServerError
+			err := utils.CheckStatusCode500Error(err)
+			return err
 		}
 		body, err := ioutil.ReadAll(httpResp.Body)
 		if err != nil {

--- a/pkg/cmd/edge_services/update/update.go
+++ b/pkg/cmd/edge_services/update/update.go
@@ -166,7 +166,8 @@ func updateService(client *sdk.APIClient, out io.Writer, id int64, cmd *cobra.Co
 	resp, httpResp, err := api.PatchService(c, id).UpdateServiceRequest(request.UpdateServiceRequest).Execute()
 	if err != nil {
 		if httpResp == nil || httpResp.StatusCode >= 500 {
-			return utils.ErrorInternalServerError
+			err := utils.CheckStatusCode500Error(err)
+			return err
 		}
 		body, err := ioutil.ReadAll(httpResp.Body)
 		if err != nil {

--- a/utils/errors.go
+++ b/utils/errors.go
@@ -30,4 +30,5 @@ var (
 	ErrorUnmarshalAzionJsonFile     = errors.New("Failed to parse azion.json. Verify the file format.")
 	ErrorMarshalAzionJsonFile       = errors.New("Failed to encode azion.json. Verify the file format.")
 	ErrorWritingAzionJsonFile       = errors.New("Failed to write azion.json. Verify the file format.")
+	ErrorTimeoutAPICall             = errors.New("CLI timed out while carrying out this action. Please verify if it was completed successfully")
 )

--- a/utils/helpers.go
+++ b/utils/helpers.go
@@ -182,3 +182,13 @@ func WriteAzionJsonContent(conf *contracts.AzionApplicationOptions) error {
 
 	return nil
 }
+
+// checks varying errors that may occur when status code is 500
+func CheckStatusCode500Error(err error) error {
+
+	if strings.Contains(err.Error(), "Client.Timeout") {
+		return ErrorTimeoutAPICall
+	}
+
+	return ErrorInternalServerError
+}


### PR DESCRIPTION
**WHAT**
Azioncli sometimes would return an internal server error message, even though the process finished successfully. This was due to a timeout within our SDK. 
The solution was to provide our own timeout (currently 10 seconds) and, in case the timeout still happened, print a clarifying message to the user. 

**WHY**
[ENG-20839]

[ENG-20839]: https://aziontech.atlassian.net/browse/ENG-20839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ