### PR TITLE
fix: change type to trigger in --details

### DIFF
--- a/pkg/cmd/edge_services/resources/list/list.go
+++ b/pkg/cmd/edge_services/resources/list/list.go
@@ -89,7 +89,7 @@ func listAllResources(client *sdk.APIClient, out io.Writer, opts *contracts.List
 
 	tp := printer.NewTab(out)
 	if opts.Details {
-		fields = append(fields, "LastEditor", "UpdatedAt", "ContentType", "Type")
+		fields = append(fields, "LastEditor", "UpdatedAt", "ContentType", "Trigger")
 		headers = append(headers, "LAST EDITOR", "LAST MODIFIED", "CONTENT TYPE", "TRIGGER")
 	}
 


### PR DESCRIPTION
**WHAT**
When calling `azioncli edge_services resources list <ID>` with the flag `--details`, CLI would return an error. 

**WHY**
[NO ISSUE]