### PR TITLE
fix: exemples showing correct command tree

### DIFF
--- a/pkg/cmd/webapp/build/build.go
+++ b/pkg/cmd/webapp/build/build.go
@@ -33,7 +33,7 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		Example: heredoc.Doc(`
-        $ azioncli build
+        $ azioncli webapp build
         `),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return command.run()

--- a/pkg/cmd/webapp/init/init.go
+++ b/pkg/cmd/webapp/init/init.go
@@ -79,9 +79,9 @@ func newCobraCmd(init *initCmd) *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		Example: heredoc.Doc(`
-        $ azioncli init --name "thisisatest" --type javascript
-        $ azioncli init --name "thisisatest" --type flareact
-        $ azioncli init --name "thisisatest" --type nextjs
+        $ azioncli webapp init --name "thisisatest" --type javascript
+        $ azioncli webapp init --name "thisisatest" --type flareact
+        $ azioncli webapp init --name "thisisatest" --type nextjs
         `),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return init.run(info, options)

--- a/pkg/cmd/webapp/publish/publish.go
+++ b/pkg/cmd/webapp/publish/publish.go
@@ -74,7 +74,7 @@ func newCobraCmd(publish *publishCmd) *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		Example: heredoc.Doc(`
-        $ azioncli publish
+        $ azioncli webapp publish
         `),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return publish.run(publish.f, options)


### PR DESCRIPTION
**WHAT**
Webapp examples were different from how you actually use them.
 