### PR TITLE
chore: add goreleaser support

### DIFF
--- a/.github/workflows/deploy_prod.yml
+++ b/.github/workflows/deploy_prod.yml
@@ -63,3 +63,18 @@ jobs:
               --exclude "*" --include "azioncli*" \
               dist/$distro/$arch/ s3://azion-downloads/$distro/$arch/; \
           done < BUILD
+
+      - name: set bin_version environment variable 
+        run: echo "BIN_VERSION=$(git describe --tags)" >> $GITHUB_ENV
+          
+
+      - uses: goreleaser/goreleaser-action@v2
+        with:
+          # either 'goreleaser' (default) or 'goreleaser-pro'
+          distribution: goreleaser
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          API_URL: https://api.azionapi.net
+          AUTH_URL: https://sso.azion.com/api/user/me

--- a/.github/workflows/deploy_prod.yml
+++ b/.github/workflows/deploy_prod.yml
@@ -70,7 +70,6 @@ jobs:
 
       - uses: goreleaser/goreleaser-action@v2
         with:
-          # either 'goreleaser' (default) or 'goreleaser-pro'
           distribution: goreleaser
           version: latest
           args: release --rm-dist

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,55 @@
+builds:
+  - env:
+      - CGO_ENABLED=0
+    binary: azioncli
+    main: ./cmd/azioncli
+    ldflags:
+        - -X github.com/aziontech/azion-cli/pkg/cmd/version.BinVersion={{ .Env.BIN_VERSION }}
+        - -X github.com/aziontech/azion-cli/pkg/constants.AuthURL={{ .Env.AUTH_URL }}
+        - -X github.com/aziontech/azion-cli/pkg/constants.ApiURL={{ .Env.API_URL }}
+    goos:
+      - linux
+      - darwin
+archives:
+  - replacements:
+      darwin: Darwin
+      linux: Linux
+      amd64: x86_64
+
+brews:
+- name: azioncli
+  homepage: https://github.com/aziontech/azion-cli
+  description: The developer friendly way to interact with Azion
+  license: "MIT"
+  dependencies:
+      - name: git
+      - name: jq
+  tap:
+    owner: aziontech
+    name: homebrew-tap
+
+nfpms:
+  - id: packages
+    license: MIT
+    package_name: azioncli
+    maintainer: aziontech
+    homepage: https://github.com/aziontech/azion-cli
+    bindir: /usr/local/bin
+    builds:
+      - azioncli
+    formats:
+      - apk
+      - deb
+      - rpm
+
+checksum:
+  name_template: "{{ .ProjectName }}_v{{ .Env.BIN_VERSION }}_checksum"
+snapshot:
+  name_template: "{{ incpatch .Env.BIN_VERSION }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+      

--- a/README.md
+++ b/README.md
@@ -9,12 +9,25 @@ The Azion CLI (command-line interface) is an open source tool that enables you t
 The developer friendly way to interact with Azion!
 
 ## Quick links
+* [Downloading] (#downloading)
 * [Building](#building)
 * [How to Use](#How-to-Use)
 * [Commands Reference](https://github.com/aziontech/azion-cli/wiki/azioncli)
 * [Contributing](CONTRIBUTING.md)
 * [Code of Conduct](CODE_OF_CONDUCT.md)
 * [License](#License)
+
+
+## Downloading
+
+There are two ways to download and use `azioncli`
+The first, is the regular way of cloning this repository and [building] (#building) the project manually. 
+However, `azioncli` is also available as `homebrew`, `rpm`, `deb` and `apk` packages. 
+
+To use `rpm`, `deb` and `apk` packages, please visit our [releases] (https://github.com/aziontech/azion-cli/releases) page, and download the desired package. 
+
+To download azioncli through Homebrew, use the following:
+* `brew install aziontech/tap/azioncli`
 
 
 ## Building

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The Azion CLI (command-line interface) is an open source tool that enables you t
 The developer friendly way to interact with Azion!
 
 ## Quick links
-* [Downloading] (#downloading)
+* [Downloading](#downloading)
 * [Building](#building)
 * [How to Use](#How-to-Use)
 * [Commands Reference](https://github.com/aziontech/azion-cli/wiki/azioncli)
@@ -21,10 +21,10 @@ The developer friendly way to interact with Azion!
 ## Downloading
 
 There are two ways to download and use `azioncli`
-The first, is the regular way of cloning this repository and [building] (#building) the project manually. 
+The first, is the regular way of cloning this repository and [building](#building) the project manually. 
 However, `azioncli` is also available as `homebrew`, `rpm`, `deb` and `apk` packages. 
 
-To use `rpm`, `deb` and `apk` packages, please visit our [releases] (https://github.com/aziontech/azion-cli/releases) page, and download the desired package. 
+To use `rpm`, `deb` and `apk` packages, please visit our [releases](https://github.com/aziontech/azion-cli/releases) page, and download the desired package. 
 
 To download azioncli through Homebrew, use the following:
 * `brew install aziontech/tap/azioncli`

--- a/pkg/cmd/webapp/init/init.go
+++ b/pkg/cmd/webapp/init/init.go
@@ -80,9 +80,9 @@ func newCobraCmd(init *initCmd) *cobra.Command {
 		SilenceErrors: true,
 		Example: heredoc.Doc(`
 		$ azioncli init --help
-		$ azioncli init --name "thisisatest" --type javascript
-		$ azioncli init --name "thisisatest" --type flareact
-		$ azioncli init --name "thisisatest" --type nextjs
+		$ azioncli webapp init --name "thisisatest" --type javascript
+		$ azioncli webapp init --name "thisisatest" --type flareact
+		$ azioncli webapp init --name "thisisatest" --type nextjs
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return init.run(info, options)

--- a/pkg/cmd/webapp/publish/publish.go
+++ b/pkg/cmd/webapp/publish/publish.go
@@ -75,7 +75,6 @@ func newCobraCmd(publish *publishCmd) *cobra.Command {
 		SilenceErrors: true,
 		Example: heredoc.Doc(`
 		$ azioncli webapp publish --help
-		$ azioncli webapp publish --yes
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return publish.run(publish.f, options)

--- a/utils/errors.go
+++ b/utils/errors.go
@@ -5,7 +5,6 @@ import "errors"
 var (
 	//Generic errors that can be used by any package
 	GenericUseHelp                  = errors.New("Use -h or --help for more information")
-	ErrorConvertingIdArgumentToInt  = errors.New("You must provide a valid id")
 	ErrorConvertingStringToBool     = errors.New("You must provide a valid value. Use -h or --help for more information")
 	ErrorHandlingFile               = errors.New("You must provide a valid file name. Use -h or --help for more information")
 	ErrorEmptyFile                  = errors.New("Content file may not be empty")


### PR DESCRIPTION
**WHAT**
- adding goreleaser suport: azioncli is available as `homebrew`, `rpm`, `deb` and `apk` packages;
- azioncli can be downloaded through homebew, using: `brew install aziontech/tap/azioncli` (when pushed to master);
- removing unused error message.