### PR TITLE
fix: correct identation in package.json on first init

### DIFF
--- a/pkg/cmd/webapp/init/init.go
+++ b/pkg/cmd/webapp/init/init.go
@@ -151,6 +151,10 @@ func (cmd *InitCmd) run(info *InitInfo, options *contracts.AzionApplicationOptio
 			return err
 		}
 
+		if err := UpdateScript(info, cmd); err != nil {
+			return err
+		}
+
 		if err := cmd.organizeJsonFile(options, info); err != nil {
 			return err
 		}
@@ -288,10 +292,6 @@ func InitJavascript(info *InitInfo, cmd *InitCmd) (string, int, error) {
 
 	output, exitCode, err := cmd.CommandRunner(conf.InitData.Cmd, envs)
 	fmt.Println("output: ", output)
-
-	if err := UpdateScript(info, cmd); err != nil {
-		return "", 0, err
-	}
 
 	return output, exitCode, err
 }


### PR DESCRIPTION
**WHAT**
When you used `azioncli webapp init` for the first time in your project, package.json file would be incorrectly indented.