### PR TITLE
fix: correct indentation in package.json on first init

### DIFF
--- a/pkg/cmd/webapp/init/init.go
+++ b/pkg/cmd/webapp/init/init.go
@@ -158,6 +158,10 @@ func (cmd *InitCmd) run(info *InitInfo, options *contracts.AzionApplicationOptio
 			return err
 		}
 
+		if err = UpdateScript(info, cmd, path); err != nil {
+			return err
+		}
+
 		if err := cmd.organizeJsonFile(options, info); err != nil {
 			return err
 		}
@@ -223,10 +227,6 @@ func (cmd *InitCmd) runInitCmdLine(info *InitInfo) error {
 	}
 
 	if err = addGitignor(cmd, path); err != nil {
-		return err
-	}
-
-	if err = UpdateScript(info, cmd, path); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
**WHAT**
When you used `azioncli webapp init` for the first time in your project, package.json file would be incorrectly indented.