### PR TITLE
chore: remove 'command not specified' message

### DIFF
--- a/messages/webapp/errors.go
+++ b/messages/webapp/errors.go
@@ -21,8 +21,6 @@ var (
 	ErrorCreateDomain      = errors.New("Failed to create the Domain: %s. Check your settings and try again. If the error persists, contact Azion support")
 	ErrorUpdateDomain      = errors.New("Failed to update the Domain: %s. Check your settings and try again. If the error persists, contact Azion support")
 
-	ErrorWebappInitCmdNotSpecified     = errors.New("Init step command not specified. No action will be taken")
-	ErrorWebappBuildCmdNotSpecified    = errors.New("Build step command not specified. No action will be taken")
 	ErrorNpmNotInstalled               = errors.New("Failed to open the NPM package Manager. Visit the website 'https://nodejs.org/en/download/' and follow the instructions to install the Node.js JavaScript runtime environment in your operating system. Node.js installation includes the NPM package manager")
 	FailedUpdatingScriptsDeployField   = errors.New("Failed to update scripts.deploy field in package.json file. Make sure you have the needed permissions and try again. If the error persists, contact the Azion support")
 	FailedUpdatingScriptsBuildField    = errors.New("Failed to update scripts.build field in package.json file. Make sure you have the needed permissions and try again. If the error persists, contact the Azion support")

--- a/messages/webapp/messages.go
+++ b/messages/webapp/messages.go
@@ -35,7 +35,6 @@ var (
 	WebappPublishUsage                       = "publish"
 	WebappPublishShortDescription            = "Publishes a Web Application on the Azion platform"
 	WebappPublishLongDescription             = "Publishes a Web Application based on the Azion’s Platform"
-	WebappPublishCmdNotSpecified             = "Publish pre command not specified. No action will be taken\n"
 	WebappPublishRunningCmd                  = "Running publish pre command:\n\n"
 	WebappPublishOutputDomainSuccess         = "\nTo visualize your application access the domain: %s\n"
 	WebappPublishOutputCachePurge            = "Domain cache was purged"

--- a/pkg/cmd/webapp/build/build.go
+++ b/pkg/cmd/webapp/build/build.go
@@ -152,8 +152,6 @@ func BuildJavascript(cmd *BuildCmd) (string, int, error) {
 		return output, exitCode, nil
 	}
 
-	fmt.Println(msg.ErrorWebappBuildCmdNotSpecified)
-
 	return "", 0, nil
 }
 
@@ -194,8 +192,6 @@ func BuildFlareactNextjs(cmd *BuildCmd) (string, int, error) {
 		}
 		return output, exitCode, nil
 	}
-
-	fmt.Println(msg.ErrorWebappBuildCmdNotSpecified)
 
 	return "", 0, nil
 }

--- a/pkg/cmd/webapp/init/init.go
+++ b/pkg/cmd/webapp/init/init.go
@@ -309,8 +309,6 @@ func InitJavascript(info *InitInfo, cmd *InitCmd, conf *contracts.AzionApplicati
 		return output, exitCode, nil
 	}
 
-	fmt.Fprintf(cmd.Io.Out, "$ %s\n", msg.ErrorWebappInitCmdNotSpecified)
-
 	return "", 0, nil
 }
 
@@ -332,8 +330,6 @@ func InitNextjs(info *InitInfo, cmd *InitCmd, conf *contracts.AzionApplicationCo
 		showInstructions()
 		return output, exitCode, nil
 	}
-
-	fmt.Fprintf(cmd.Io.Out, "$ %s\n", msg.ErrorWebappInitCmdNotSpecified)
 
 	return "", 0, nil
 
@@ -370,8 +366,6 @@ func InitFlareact(info *InitInfo, cmd *InitCmd, conf *contracts.AzionApplication
 		return nil
 	}
 
-	fmt.Fprintf(cmd.Io.Out, "$ %s\n", msg.ErrorWebappInitCmdNotSpecified)
-
 	if err = cmd.Mkdir(info.PathWorkingDir+"/public", os.ModePerm); err != nil {
 		return utils.ErrorCreateDir
 	}
@@ -403,7 +397,7 @@ func UpdateScript(info *InitInfo, cmd *InitCmd, path string) error {
 
 	packJsonReplaceBuild, err := sjson.Set(string(packageJson), "scripts.build", "azioncli webapp build")
 	if err != nil {
-		return msg.ErrorWebappBuildCmdNotSpecified
+		return msg.FailedUpdatingScriptsBuildField
 	}
 
 	packJsonReplaceDeploy, err := sjson.Set(packJsonReplaceBuild, "scripts.deploy", "azioncli webapp publish")

--- a/pkg/cmd/webapp/publish/publish.go
+++ b/pkg/cmd/webapp/publish/publish.go
@@ -314,7 +314,6 @@ func (cmd *publishCmd) runPublishPreCmdLine() error {
 	}
 
 	if conf.PublishData.Cmd == "" {
-		fmt.Fprintf(cmd.io.Out, msg.WebappPublishCmdNotSpecified)
 		return nil
 	}
 


### PR DESCRIPTION
**WHAT**
- Remove message saying that no cmd was found and thus no action will be taken. This message was confusing and made no sense.