### PR TITLE
chore: improve error message when go is not found

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ GO := $(shell which go)
 NAME := azioncli
 
 ifeq (, $(GO))
-$(error "No go binary found in $(PATH), please install go before continue")
+$(error "No go binary found in $(PATH), please install go 1.17 before continue")
 endif
 
 GOPATH ?= $(shell $(GO) env GOPATH)

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,10 @@ SHELL := env PATH=$(PATH) /bin/bash
 GO := $(shell which go)
 NAME := azioncli
 
+ifeq (, $(GO))
+$(error "No go binary found in $(PATH), please install go before continue")
+endif
+
 GOPATH ?= $(shell $(GO) env GOPATH)
 GOBIN ?= $(GOPATH)/bin
 GOSEC ?= $(GOBIN)/gosec


### PR DESCRIPTION
Before this change, the error message is:

/bin/bash: line 1: version: command not found
make: *** [Makefile:84: build] Error 127

After that:

Makefile:7: *** "No go binary found in
/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin, please install go before continue".  Stop.