### PR TITLE
feat: add interactive terminal input for AWS credentials

### DIFF
--- a/messages/webapp/errors.go
+++ b/messages/webapp/errors.go
@@ -7,7 +7,7 @@ var (
 
 	ErrOpeningConfigFile         = errors.New("Failed to open the config.json file. The file doesn't exist, is corrupted, or has an invalid JSON format. Verify if the file was deleted or changed or run the 'azioncli webapp init' command again")
 	ErrUnmarshalConfigFile       = errors.New("Failed to parse the config.json file. Verify if the file format is JSON or fix its content according to the JSON format specification at https://www.json.org/json-en.html")
-	ErrReadEnvFile               = errors.New("Failed to read the build.env file. Verify if the file was deleted or changed or run the 'azioncli webapp init' command again")
+	ErrReadEnvFile               = errors.New("Failed to read the webdev.env file. Verify if the file is corrupted or changed or run the 'azioncli webapp publish' command again")
 	ErrFailedToRunBuildCommand   = errors.New("Failed to run the build step command. Verify if the command is correct and check the output above for more details. Try the 'azioncli webapp build' command again or contact Azion's support")
 	ErrFailedToRunInitCommand    = errors.New("Failed to run the init step command. Verify if the command is correct and check the output above for more details. Try the 'azioncli webapp build' command again or contact Azion's support")
 	ErrFailedToRunPublishCommand = errors.New("Failed to run the publish step command. Verify if the command is correct and check the output above for more details. Try the 'azioncli webapp build' command again or contact Azion's support")
@@ -38,6 +38,7 @@ var (
 	ErrorArgsFlag       = errors.New("Failed to read the args file. Verify if the file name and its path are correct and the file's content has a valid JSON format")
 	ErrorParseArgs      = errors.New("Failed to parse JSON args. Verify if the file's content has a valid JSON format")
 
-	ErrorGetAllTags     = errors.New("Failed returning all Reference tags in a repository. Verify your repository tags and try again. If the error persists, contact Azion support.")
-	ErrorIterateAllTags = errors.New("Failed to iterate over Git reference. Verify the credentials to access your Git repository and try again. If the error persists, contact Azion support.")
+	ErrorGetAllTags       = errors.New("Failed returning all Reference tags in a repository. Verify your repository tags and try again. If the error persists, contact Azion support.")
+	ErrorIterateAllTags   = errors.New("Failed to iterate over Git reference. Verify the credentials to access your Git repository and try again. If the error persists, contact Azion support.")
+	ErrorWritingWebdevEnv = errors.New("Failed to write 'webdev.env' file. Verify if the file is writable and/or you have access to it, if the data format is JSON, or fix the content according to the JSON format specification at https://www.json.org/json-en.html")
 )

--- a/messages/webapp/messages.go
+++ b/messages/webapp/messages.go
@@ -49,4 +49,8 @@ var (
 	WebappPublishOutputDomainUpdate          = "Updated Domain %s with ID %d\n"
 	WebappPublishFlagHelp                    = "Displays more information about the publish subcommand"
 	WebappPublishPropagation                 = "Content is being propagated to all Azion POPs and it might take a few minutes for all edges to be up to date\n"
+
+	WebappAWSMesaage = "Please inform your AWS credentials below:\n"
+	WebappAWSSecret  = "AWS_SECRET_ACCESS_KEY: "
+	WebappAWSAcess   = "AWS_ACCESS_KEY_ID: "
 )

--- a/pkg/cmd/webapp/build/build.go
+++ b/pkg/cmd/webapp/build/build.go
@@ -2,10 +2,10 @@ package build
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
-	"regexp"
 
 	"github.com/tidwall/gjson"
 
@@ -27,6 +27,7 @@ type BuildCmd struct {
 	ConfigRelativePath string
 	GetWorkDir         func() (string, error)
 	EnvLoader          func(path string) ([]string, error)
+	Stat               func(path string) (fs.FileInfo, error)
 }
 
 func NewCmd(f *cmdutil.Factory) *cobra.Command {
@@ -64,6 +65,7 @@ func newBuildCmd(f *cmdutil.Factory) *BuildCmd {
 		GetWorkDir:         utils.GetWorkingDir,
 		EnvLoader:          utils.LoadEnvVarsFromFile,
 		WriteFile:          os.WriteFile,
+		Stat:               os.Stat,
 	}
 }
 
@@ -100,8 +102,24 @@ func RunBuildCmdLine(cmd *BuildCmd, typeLang string) error {
 		return err
 	}
 
-	envs, err := cmd.EnvLoader(conf.BuildData.Env)
+	path, err := utils.GetWorkingDir()
 	if err != nil {
+		return err
+	}
+
+	envs := make([]string, 0)
+
+	_, err = cmd.Stat(path + "/azion/webdev.env")
+	if err == nil {
+		envs, err = cmd.EnvLoader(conf.BuildData.Env)
+		if err != nil {
+			return msg.ErrReadEnvFile
+		}
+	} else if errors.Is(err, os.ErrNotExist) {
+		if typeLang == "nextjs" || typeLang == "flareact" {
+			envs = insertAWSCredentials(cmd)
+		}
+	} else {
 		return msg.ErrReadEnvFile
 	}
 
@@ -111,16 +129,16 @@ func RunBuildCmdLine(cmd *BuildCmd, typeLang string) error {
 	}
 
 	switch typeLang {
-	case "javascript":
-		err = BuildJavascript(cmd, conf, envs)
+	case "javascript", "nextjs", "flareact":
+		err = BuildWebapp(cmd, conf, envs)
 		if err != nil {
 			return err
 		}
-	case "nextjs", "flareact":
-		err = BuildFlareactNextjs(cmd, conf, envs)
-		if err != nil {
-			return err
+		errEnv := writeWebdevEnvFile(cmd, path, envs)
+		if errEnv != nil {
+			return errEnv
 		}
+
 	default:
 		return utils.ErrorUnsupportedType
 	}
@@ -132,27 +150,12 @@ func (cmd *BuildCmd) Run() error {
 	return cmd.run()
 }
 
-func BuildJavascript(cmd *BuildCmd, conf *contracts.AzionApplicationConfig, envs []string) error {
+func BuildWebapp(cmd *BuildCmd, conf *contracts.AzionApplicationConfig, envs []string) error {
 
 	err := runCommand(cmd, conf, envs)
 	if err != nil {
 		return err
 	}
-	return nil
-}
-
-func BuildFlareactNextjs(cmd *BuildCmd, conf *contracts.AzionApplicationConfig, envs []string) error {
-
-	err := checkMandatoryEnv(envs)
-	if err != nil {
-		return err
-	}
-
-	err = runCommand(cmd, conf, envs)
-	if err != nil {
-		return err
-	}
-
 	return nil
 }
 
@@ -195,26 +198,6 @@ func checkArgsJson(cmd *BuildCmd) error {
 	return nil
 }
 
-func checkMandatoryEnv(env []string) error {
-	awsSecret := regexp.MustCompile("^AWS_SECRET_ACCESS_KEY=.+")
-	awsAccess := regexp.MustCompile("^AWS_ACCESS_KEY_ID=.+")
-	yesAccess := false
-	yesSecret := false
-	for _, item := range env {
-		access := awsAccess.FindString(item)
-		secret := awsSecret.FindString(item)
-		if access != "" {
-			yesAccess = true
-		} else if secret != "" {
-			yesSecret = true
-		}
-	}
-	if !yesAccess || !yesSecret {
-		return msg.ErrorMandatoryEnvs
-	}
-	return nil
-}
-
 func runCommand(cmd *BuildCmd, conf *contracts.AzionApplicationConfig, envs []string) error {
 
 	//if no cmd is specified, we just return nil (no error)
@@ -253,5 +236,46 @@ func runCommand(cmd *BuildCmd, conf *contracts.AzionApplicationConfig, envs []st
 
 	fmt.Fprintf(cmd.Io.Out, msg.WebappBuildSuccessful)
 
+	return nil
+}
+
+func insertAWSCredentials(cmd *BuildCmd) []string {
+
+	var access string
+	var secret string
+	envs := make([]string, 2)
+
+	filled := false
+
+	fmt.Fprintf(cmd.Io.Out, "%s \n", msg.WebappAWSMesaage)
+
+	for !filled {
+		fmt.Fprintf(cmd.Io.Out, "%s ", msg.WebappAWSAcess)
+		fmt.Fscanln(cmd.Io.In, &access)
+		fmt.Fprintf(cmd.Io.Out, "%s ", msg.WebappAWSSecret)
+		fmt.Fscanln(cmd.Io.In, &secret)
+		fmt.Fprintf(cmd.Io.Out, "\n")
+		if len(access) > 0 && len(secret) > 0 {
+			filled = true
+		}
+		envs[0] = "AWS_ACCESS_KEY_ID=" + access
+		envs[1] = "AWS_SECRET_ACCESS_KEY=" + secret
+	}
+
+	return envs
+
+}
+
+func writeWebdevEnvFile(cmd *BuildCmd, path string, envs []string) error {
+	var fileContent string
+
+	for _, env := range envs {
+		fileContent += env + "\n"
+	}
+
+	err := cmd.WriteFile(path+"/azion/webdev.env", []byte(fileContent), 0644)
+	if err != nil {
+		return err
+	}
 	return nil
 }

--- a/pkg/cmd/webapp/build/build_test.go
+++ b/pkg/cmd/webapp/build/build_test.go
@@ -3,6 +3,7 @@ package build
 import (
 	"bytes"
 	"errors"
+	"io/fs"
 	"os"
 	"testing"
 
@@ -33,6 +34,14 @@ func TestBuild(t *testing.T) {
 
 		command.FileReader = func(path string) ([]byte, error) {
 			return jsonContent.Bytes(), nil
+		}
+
+		command.WriteFile = func(filename string, data []byte, perm fs.FileMode) error {
+			return nil
+		}
+
+		command.Stat = func(path string) (fs.FileInfo, error) {
+			return nil, nil
 		}
 
 		command.CommandRunner = func(cmd string, envs []string) (string, int, error) {
@@ -136,7 +145,8 @@ func TestBuild(t *testing.T) {
 		jsonContent := bytes.NewBufferString(`
 	   {
 			"build": {
-		   		"cmd": "npm run build"
+		   		"cmd": "npm run build",
+				"output-ctrl": "on-error"
 	   		},
 			"type": "javascript"
 	   }
@@ -146,6 +156,9 @@ func TestBuild(t *testing.T) {
 
 		command.FileReader = func(path string) ([]byte, error) {
 			return jsonContent.Bytes(), nil
+		}
+		command.Stat = func(path string) (fs.FileInfo, error) {
+			return nil, nil
 		}
 		command.EnvLoader = func(path string) ([]string, error) {
 			return nil, utils.ErrorLoadingEnvVars

--- a/pkg/cmd/webapp/webapp_test.go
+++ b/pkg/cmd/webapp/webapp_test.go
@@ -244,12 +244,20 @@ func TestWebappCmd(t *testing.T) {
 			return "Build completed", 0, nil
 		}
 
+		buildCommand.Stat = func(path string) (fs.FileInfo, error) {
+			return nil, nil
+		}
+
 		buildCommand.EnvLoader = func(path string) ([]string, error) {
 			return buildEnvs, nil
 		}
 
 		buildCommand.GetWorkDir = func() (string, error) {
 			return "", nil
+		}
+
+		buildCommand.WriteFile = func(filename string, data []byte, perm fs.FileMode) error {
+			return nil
 		}
 
 		cmdBuild := buildcmd.NewCobraCmd(buildCommand)
@@ -400,6 +408,14 @@ func TestWebappCmd(t *testing.T) {
 
 		buildCommand.EnvLoader = func(path string) ([]string, error) {
 			return buildEnvs, nil
+		}
+
+		buildCommand.Stat = func(path string) (fs.FileInfo, error) {
+			return nil, nil
+		}
+
+		buildCommand.WriteFile = func(filename string, data []byte, perm fs.FileMode) error {
+			return nil
 		}
 
 		buildCommand.GetWorkDir = func() (string, error) {


### PR DESCRIPTION
**WHAT**
- Add interactive terminal input for AWS credentials;
- Webdev.env file is written after the process worked successfully. 
- Unit tests;
- Functional tests.