### PR TITLE
feat: add cdn type to edge_applications

### DIFF
--- a/messages/edge_applications/errors.go
+++ b/messages/edge_applications/errors.go
@@ -31,6 +31,7 @@ var (
 	ErrorMandatoryEnvs                 = errors.New("You must provide the following enviroment variables: AWS_SECRET_ACCESS_KEY and AWS_ACCESS_KEY_ID. Please edit the following file 'azion/webdev.env' and add your credentials")
 	ErrorFailedCreatingWorkerDirectory = errors.New("Failed to create the worker directory. The worker's parent directory is read-only and/or isn't accessible. Change the permissions of the parent directory to read and write and/or give access to it")
 	ErrorFailedCreatingPublicDirectory = errors.New("Failed to create the public directory. The public's parent directory is read-only and/or isn't accessible. Change the permissions of the parent directory to read and write and/or give access to it")
+	ErrorFailedCreatingAzionDirectory  = errors.New("Failed to create the azion directory. The public's parent directory is read-only and/or isn't accessible. Change the permissions of the parent directory to read and write and/or give access to it")
 
 	ErrorCreateFunction = errors.New("Failed to create edge function: %s. Check your settings and try again. If the error persists, contact Azion support")
 	ErrorUpdateFunction = errors.New("Failed to update the Edge Function: %s. Check your settings and try again. If the error persists, contact Azion support")

--- a/messages/edge_applications/messages.go
+++ b/messages/edge_applications/messages.go
@@ -21,6 +21,7 @@ var (
 	EdgeApplicationsBuildStart            = "Building your Web Application\n"
 	EdgeApplicationsBuildSuccessful       = "Your Web Application was built successfully\n"
 	EdgeApplicationsBuildFlagHelp         = "Displays more information about the build subcommand"
+	EdgeApplicationsBuildCdn              = "Skipping build step. Build isn't applied to the type 'CDN'"
 
 	//init cmd
 	EdgeApplicationsInitUsage = `init [flags]
@@ -50,6 +51,7 @@ var (
 	EdgeApplicationsPublishLongDescription             = "Publishes a Web Application based on the Azion’s Platform"
 	EdgeApplicationsPublishRunningCmd                  = "Running pre publish command:\n\n"
 	EdgeApplicationsPublishSuccessful                  = "Your Web Application was published successfully\n"
+	EdgeApplicationsCdnPublishSuccessful               = "Your CDN Edge Application was published successfully\n"
 	EdgeApplicationsPublishOutputDomainSuccess         = "\nTo visualize your application access the domain: %s\n"
 	EdgeApplicationsPublishOutputCachePurge            = "Domain cache was purged\n"
 	EdgeApplicationsPublishOutputEdgeFunctionCreate    = "Created Edge Function %s with ID %d\n"

--- a/pkg/cmd/edge_applications/build/build.go
+++ b/pkg/cmd/edge_applications/build/build.go
@@ -85,6 +85,12 @@ func (cmd *BuildCmd) run() error {
 	}
 
 	typeLang := gjson.Get(string(file), "type")
+
+	if typeLang.String() == "cdn" {
+		fmt.Fprintf(cmd.Io.Out, "%s\n", msg.EdgeApplicationsBuildCdn)
+		return nil
+	}
+
 	err = RunBuildCmdLine(cmd, typeLang.String())
 	if err != nil {
 		return err

--- a/pkg/cmd/edge_applications/init/init.go
+++ b/pkg/cmd/edge_applications/init/init.go
@@ -163,9 +163,7 @@ func (cmd *InitCmd) run(info *InitInfo, options *contracts.AzionApplicationOptio
 		return err
 	}
 
-	shouldFetchTemplates := true
-
-	shouldFetchTemplates, err = shouldFetch(cmd, info)
+	shouldFetchTemplates, err := shouldFetch(cmd, info)
 	if err != nil {
 		return err
 	}
@@ -616,7 +614,7 @@ func initCdn(cmd *InitCmd, path string, info *InitInfo) error {
 			return utils.ErrorInternalServerError
 		}
 
-		fmt.Fprintf(cmd.Io.Out, fmt.Sprintf(msg.EdgeApplicationsInitSuccessful+"\n", info.Name))
+		fmt.Fprintf(cmd.Io.Out, fmt.Sprintf(msg.EdgeApplicationsInitSuccessful+"\n", info.Name)) // nolint:all
 
 	}
 

--- a/pkg/cmd/edge_applications/init/init.go
+++ b/pkg/cmd/edge_applications/init/init.go
@@ -572,7 +572,7 @@ func runCommand(cmd *InitCmd, conf *contracts.AzionApplicationConfig, envs []str
 
 func initCdn(cmd *InitCmd, path string, info *InitInfo) error {
 	var err error
-	shouldFetchTemplates := true
+	var shouldFetchTemplates bool
 	options := &contracts.AzionApplicationCdn{}
 
 	if info.Name == "" {

--- a/pkg/cmd/edge_applications/init/init.go
+++ b/pkg/cmd/edge_applications/init/init.go
@@ -624,7 +624,7 @@ func initCdn(cmd *InitCmd, path string, info *InitInfo) error {
 func shouldFetch(cmd *InitCmd, info *InitInfo) (bool, error) {
 	var response string
 	var err error
-	shouldFetchTemplates := true
+	var shouldFetchTemplates bool
 	if empty, _ := cmd.IsDirEmpty("./azion"); !empty {
 		if info.NoOption || info.YesOption {
 			shouldFetchTemplates = yesNoFlagToResponse(info)

--- a/pkg/cmd/edge_applications/publish/publish_test.go
+++ b/pkg/cmd/edge_applications/publish/publish_test.go
@@ -98,7 +98,7 @@ func TestPublishCmd(t *testing.T) {
 
 		// Specified publish.env file but it cannot be read correctly
 		cmd.FileReader = func(path string) ([]byte, error) {
-			return []byte(`{"publish": {"pre_cmd": "ls", "env": "./azion/publish.env", "output-ctrl": "on-error", "default": "ls -lia"}}`), nil
+			return []byte(`{"publish": {"pre_cmd": "ls", "env": "./azion/publish.env", "output-ctrl": "on-error", "default": "ls -la"}}`), nil
 		}
 		cmd.EnvLoader = func(path string) ([]string, error) {
 			return []string{"UEBA=OBA", "FAZER=UM_PENSO"}, nil

--- a/pkg/contracts/contracts.go
+++ b/pkg/contracts/contracts.go
@@ -25,6 +25,13 @@ type AzionApplicationOptions struct {
 	RtPurge     AzionJsonDataPurge       `json:"rt-purge"`
 }
 
+type AzionApplicationCdn struct {
+	Name        string                   `json:"name"`
+	Type        string                   `json:"type"`
+	Domain      AzionJsonDataDomain      `json:"domain"`
+	Application AzionJsonDataApplication `json:"application"`
+}
+
 type AzionApplicationConfig struct {
 	InitData    InitConf    `json:"init"`
 	BuildData   BuildConf   `json:"build"`
@@ -34,22 +41,22 @@ type AzionApplicationConfig struct {
 type InitConf struct {
 	Cmd        string `json:"cmd"`
 	Env        string `json:"env"`
-    OutputCtrl string `json:"output-ctrl"`
-    Default    string `json:"default"`
+	OutputCtrl string `json:"output-ctrl"`
+	Default    string `json:"default"`
 }
 
 type BuildConf struct {
 	Cmd        string `json:"cmd"`
 	Env        string `json:"env"`
 	OutputCtrl string `json:"output-ctrl"`
-    Default    string `json:"default"`
+	Default    string `json:"default"`
 }
 
 type PublishConf struct {
 	Cmd        string `json:"pre_cmd"`
 	Env        string `json:"env"`
 	OutputCtrl string `json:"output-ctrl"`
-    Default    string `json:"default"`
+	Default    string `json:"default"`
 }
 
 type CacheConf struct {

--- a/utils/helpers.go
+++ b/utils/helpers.go
@@ -134,6 +134,27 @@ func GetAzionJsonContent() (*contracts.AzionApplicationOptions, error) {
 	return conf, nil
 }
 
+func GetAzionJsonCdn() (*contracts.AzionApplicationCdn, error) {
+	path, err := GetWorkingDir()
+	if err != nil {
+		return nil, err
+	}
+	jsonConf := path + "/azion/azion.json"
+	file, err := os.ReadFile(jsonConf)
+	if err != nil {
+		fmt.Println(&jsonConf)
+		return nil, ErrorOpeningAzionJsonFile
+	}
+
+	conf := &contracts.AzionApplicationCdn{}
+	err = json.Unmarshal(file, &conf)
+	if err != nil {
+		return nil, ErrorUnmarshalAzionJsonFile
+	}
+
+	return conf, nil
+}
+
 func WriteAzionJsonContent(conf *contracts.AzionApplicationOptions) error {
 	path, err := GetWorkingDir()
 	if err != nil {


### PR DESCRIPTION
**WHAT**
- Add cdn type to edge_application web application types. This is a very simple type with only an edge application and domain. 
- Update init, build and publish commands to verify if type is cdn before anything else, as the whole process is different.