### PR TITLE
feat: add cascade delete to edge_applications

### DIFF
--- a/messages/edge_applications/errors.go
+++ b/messages/edge_applications/errors.go
@@ -60,4 +60,7 @@ var (
 	ErrorRawLogsFlag                 = errors.New("Invalid --raw-logs flag provided. The flag must have  'true' or 'false' values. Run the command 'azioncli edge_applications <subcommand> --help' to display more information and try again")
 	ErrorWebApplicationFirewallFlag  = errors.New("Invalid --webapp-firewall flag provided. The flag must have  'true' or 'false' values. Run the command 'azioncli edge_applications <subcommand> --help' to display more information and try again")
 	ErrorMinTlsVersion               = errors.New("This is not a valid TLS Version. Run azioncli edge_applications <subcommand> --help for more information")
+	ErrorMissingApplicationIdJson    = errors.New("Application ID is missing from azion.json. Please initialize and publish your project first before using cascade delete")
+	ErrorMissingAzionJson            = errors.New("Azion.json file is missing. Please initialize and publish your project first before using cascade delete")
+	ErrorFailedUpdateAzionJson       = errors.New("Failed to update azion.json file to remove IDs of deleted resource")
 )

--- a/messages/edge_applications/messages.go
+++ b/messages/edge_applications/messages.go
@@ -86,8 +86,11 @@ var (
 	EdgeApplicationDeleteUsage            = "delete --application-id <application_id> [flags]"
 	EdgeApplicationDeleteShortDescription = "Removes an Edge Function"
 	EdgeApplicationDeleteLongDescription  = "Removes an Edge Application from the Edge Applications library based on its given ID"
-	EdgeApplicationDeleteOutputSuccess    = "Edge Application %s was successfully deleted\n"
+	EdgeApplicationDeleteOutputSuccess    = "Edge Application %d was successfully deleted\n"
 	EdgeApplicationDeleteHelpFlag         = "Displays more information about the delete subcommand"
+	EdgeApplicationDeleteCascadeFlag      = "Deletes all resources created through the command azioncli edge_applications publish"
+	EdgeApplicationDeleteMissingFunction  = "Missing Edge Function ID in azion.json file. Skipping deletion"
+	EdgeApplicationDeleteCascadeSuccess   = "Cascade delete carried out successfully"
 
 	//update cmd
 	EdgeApplicationUpdateUsage                       = "update --application-id <application_id> [flags]"

--- a/pkg/api/domains/domains.go
+++ b/pkg/api/domains/domains.go
@@ -3,6 +3,7 @@ package domains
 import (
 	"context"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/aziontech/azion-cli/pkg/cmd/version"
@@ -66,4 +67,17 @@ func (c *Client) Update(ctx context.Context, req *UpdateRequest) (DomainResponse
 	}
 
 	return &domainsResponse.Results, nil
+}
+
+func (c *Client) Delete(ctx context.Context, id int64) error {
+	str := strconv.FormatInt(id, 10)
+	req := c.apiClient.DomainsApi.DelDomain(ctx, str)
+
+	httpResp, err := req.Execute()
+
+	if err != nil {
+		return utils.ErrorPerStatusCode(httpResp, err)
+	}
+
+	return nil
 }

--- a/pkg/api/edge_applications/edge_applications.go
+++ b/pkg/api/edge_applications/edge_applications.go
@@ -175,8 +175,9 @@ func (c *Client) UpdateRulesEngine(ctx context.Context, req *UpdateRulesEngineRe
 	return &edgeApplicationsResponse.Results, nil
 }
 
-func (c *Client) Delete(ctx context.Context, id string) error {
-	req := c.apiClient.EdgeApplicationsMainSettingsApi.EdgeApplicationsIdDelete(ctx, id)
+func (c *Client) Delete(ctx context.Context, id int64) error {
+	str := strconv.FormatInt(id, 10)
+	req := c.apiClient.EdgeApplicationsMainSettingsApi.EdgeApplicationsIdDelete(ctx, str)
 
 	httpResp, err := req.Execute()
 

--- a/pkg/api/edge_functions/edge_functions.go
+++ b/pkg/api/edge_functions/edge_functions.go
@@ -122,7 +122,7 @@ func (c *Client) List(ctx context.Context, opts *contracts.ListOptions) ([]EdgeF
 		Sort(opts.Sort).
 		Execute()
 
-    pages := resp.TotalPages
+	pages := resp.TotalPages
 
 	if err != nil {
 		return nil, 0, utils.ErrorPerStatusCode(httpResp, err)

--- a/pkg/cmd/edge_applications/delete/delete.go
+++ b/pkg/cmd/edge_applications/delete/delete.go
@@ -2,17 +2,44 @@ package delete
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"os"
 
 	"github.com/MakeNowJust/heredoc"
 	msg "github.com/aziontech/azion-cli/messages/edge_applications"
-	api "github.com/aziontech/azion-cli/pkg/api/edge_applications"
+	app "github.com/aziontech/azion-cli/pkg/api/edge_applications"
+	fun "github.com/aziontech/azion-cli/pkg/api/edge_functions"
 	"github.com/aziontech/azion-cli/pkg/cmdutil"
+	"github.com/aziontech/azion-cli/pkg/contracts"
+	"github.com/aziontech/azion-cli/pkg/iostreams"
+	"github.com/aziontech/azion-cli/utils"
 	"github.com/spf13/cobra"
+	"github.com/tidwall/sjson"
 )
 
+type DeleteCmd struct {
+	Io         *iostreams.IOStreams
+	GetAzion   func() (*contracts.AzionApplicationOptions, error)
+	f          *cmdutil.Factory
+	UpdateJson func(cmd *DeleteCmd) error
+}
+
 func NewCmd(f *cmdutil.Factory) *cobra.Command {
-	var application_id string
+	return NewCobraCmd(NewDeleteCmd(f))
+}
+
+func NewDeleteCmd(f *cmdutil.Factory) *DeleteCmd {
+	return &DeleteCmd{
+		Io:         f.IOStreams,
+		GetAzion:   utils.GetAzionJsonContent,
+		f:          f,
+		UpdateJson: updateAzionJson,
+	}
+}
+
+func NewCobraCmd(delete *DeleteCmd) *cobra.Command {
+	var application_id int64
 	cmd := &cobra.Command{
 		Use:           msg.EdgeApplicationDeleteUsage,
 		Short:         msg.EdgeApplicationDeleteShortDescription,
@@ -21,30 +48,109 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 		SilenceErrors: true,
 		Example: heredoc.Doc(`
         $ azioncli edge_applications delete --application-id 1234
+		$ azioncli edge_applications delete --cascade
         `),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !cmd.Flags().Changed("application-id") {
-				return msg.ErrorMissingApplicationIdArgument
-			}
-
-			client := api.NewClient(f.HttpClient, f.Config.GetString("api_url"), f.Config.GetString("token"))
-
-			ctx := context.Background()
-
-			err := client.Delete(ctx, application_id)
-			if err != nil {
-				return fmt.Errorf(msg.ErrorFailToDeleteApplication.Error(), err)
-			}
-
-			out := f.IOStreams.Out
-			fmt.Fprintf(out, msg.EdgeApplicationDeleteOutputSuccess, application_id)
-
-			return nil
+			return delete.run(cmd, application_id)
 		},
 	}
 
-	cmd.Flags().StringVarP(&application_id, "application-id", "a", "", msg.EdgeApplicationFlagId)
+	cmd.Flags().Int64VarP(&application_id, "application-id", "a", 0, msg.EdgeApplicationFlagId)
+	cmd.Flags().BoolP("cascade", "c", true, msg.EdgeApplicationFlagId)
 	cmd.Flags().BoolP("help", "h", false, msg.EdgeApplicationDeleteHelpFlag)
 
 	return cmd
+}
+
+func (del *DeleteCmd) run(cmd *cobra.Command, application_id int64) error {
+	ctx := context.Background()
+
+	if cmd.Flags().Changed("cascade") {
+		azionJson, err := del.GetAzion()
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				return msg.ErrorMissingAzionJson
+			} else {
+				return err //message with error
+			}
+		}
+		if azionJson.Application.Id == 0 {
+			return msg.ErrorMissingApplicationIdJson
+		}
+		clientapp := app.NewClient(del.f.HttpClient, del.f.Config.GetString("api_url"), del.f.Config.GetString("token"))
+		clientfunc := fun.NewClient(del.f.HttpClient, del.f.Config.GetString("api_url"), del.f.Config.GetString("token"))
+
+		err = clientapp.Delete(ctx, azionJson.Application.Id)
+		if err != nil {
+			return fmt.Errorf(msg.ErrorFailToDeleteApplication.Error(), err)
+		}
+
+		if azionJson.Function.Id == 0 {
+			fmt.Fprintf(del.f.IOStreams.Out, msg.EdgeApplicationDeleteMissingFunction)
+		} else {
+			err = clientfunc.Delete(ctx, azionJson.Function.Id)
+			if err != nil {
+				return fmt.Errorf(msg.ErrorFailToDeleteApplication.Error(), err)
+			}
+		}
+
+		fmt.Fprintf(del.f.IOStreams.Out, "%s\n", msg.EdgeApplicationDeleteCascadeSuccess)
+
+		err = del.UpdateJson(del)
+		if err != nil {
+			return err
+		}
+
+		return nil
+
+	}
+
+	if !cmd.Flags().Changed("application-id") {
+		return msg.ErrorMissingApplicationIdArgument
+	}
+
+	client := app.NewClient(del.f.HttpClient, del.f.Config.GetString("api_url"), del.f.Config.GetString("token"))
+
+	err := client.Delete(ctx, application_id)
+	if err != nil {
+		return fmt.Errorf(msg.ErrorFailToDeleteApplication.Error(), err)
+	}
+
+	out := del.f.IOStreams.Out
+	fmt.Fprintf(out, msg.EdgeApplicationDeleteOutputSuccess, application_id)
+
+	return nil
+}
+
+func updateAzionJson(cmd *DeleteCmd) error {
+	path, err := utils.GetWorkingDir()
+	if err != nil {
+		return utils.ErrorInternalServerError
+	}
+	azionJson := path + "/azion/azion.json"
+	byteAzionJson, err := os.ReadFile(azionJson)
+	if err != nil {
+		return utils.ErrorUnmarshalAzionJsonFile
+	}
+	jsonReplaceFunc, err := sjson.Set(string(byteAzionJson), "function.id", 0)
+	if err != nil {
+		return msg.ErrorFailedUpdateAzionJson
+	}
+
+	jsonReplaceApp, err := sjson.Set(jsonReplaceFunc, "application.id", 0)
+	if err != nil {
+		return msg.ErrorFailedUpdateAzionJson
+	}
+
+	jsonReplaceDomain, err := sjson.Set(jsonReplaceApp, "domain.id", 0)
+	if err != nil {
+		return msg.ErrorFailedUpdateAzionJson
+	}
+
+	err = os.WriteFile(azionJson, []byte(jsonReplaceDomain), 0644)
+	if err != nil {
+		return fmt.Errorf(utils.ErrorCreateFile.Error(), azionJson)
+	}
+
+	return nil
 }

--- a/pkg/cmd/edge_applications/delete/delete_test.go
+++ b/pkg/cmd/edge_applications/delete/delete_test.go
@@ -1,8 +1,11 @@
 package delete
 
 import (
+	"encoding/json"
+	"os"
 	"testing"
 
+	"github.com/aziontech/azion-cli/pkg/contracts"
 	"github.com/aziontech/azion-cli/pkg/httpmock"
 	"github.com/aziontech/azion-cli/pkg/testutils"
 	"github.com/stretchr/testify/assert"
@@ -11,7 +14,7 @@ import (
 
 func TestCreate(t *testing.T) {
 
-	t.Run("delete function by id", func(t *testing.T) {
+	t.Run("delete application by id", func(t *testing.T) {
 		mock := &httpmock.Registry{}
 
 		mock.Register(
@@ -30,7 +33,7 @@ func TestCreate(t *testing.T) {
 		assert.Equal(t, "Edge Application 1234 was successfully deleted\n", stdout.String())
 	})
 
-	t.Run("delete function that is not found", func(t *testing.T) {
+	t.Run("delete application that is not found", func(t *testing.T) {
 		mock := &httpmock.Registry{}
 
 		mock.Register(
@@ -46,5 +49,55 @@ func TestCreate(t *testing.T) {
 
 		_, err := cmd.ExecuteC()
 		require.Error(t, err)
+	})
+
+	t.Run("delete cascade with no azion.json file", func(t *testing.T) {
+		mock := &httpmock.Registry{}
+
+		f, _, _ := testutils.NewFactory(mock)
+
+		cmd := NewCmd(f)
+
+		cmd.SetArgs([]string{"--cascade"})
+
+		_, err := cmd.ExecuteC()
+		require.Error(t, err)
+	})
+	t.Run("cascade delete application", func(t *testing.T) {
+		mock := &httpmock.Registry{}
+		options := &contracts.AzionApplicationOptions{}
+
+		dat, _ := os.ReadFile("./fixtures/azion.json")
+		_ = json.Unmarshal(dat, options)
+
+		mock.Register(
+			httpmock.REST("DELETE", "edge_applications/666"),
+			httpmock.StatusStringResponse(204, ""),
+		)
+		mock.Register(
+			httpmock.REST("DELETE", "edge_functions/123"),
+			httpmock.StatusStringResponse(204, ""),
+		)
+
+		f, stdout, _ := testutils.NewFactory(mock)
+
+		del := NewDeleteCmd(f)
+		del.GetAzion = func() (*contracts.AzionApplicationOptions, error) {
+			return options, nil
+		}
+		del.UpdateJson = func(cmd *DeleteCmd) error {
+			return nil
+		}
+		del.f = f
+		del.Io = f.IOStreams
+
+		cmd := NewCobraCmd(del)
+
+		cmd.SetArgs([]string{"-c"})
+
+		_, err := cmd.ExecuteC()
+		require.NoError(t, err)
+
+		assert.Equal(t, "Cascade delete carried out successfully\n", stdout.String())
 	})
 }

--- a/pkg/cmd/edge_applications/delete/fixtures/azion.json
+++ b/pkg/cmd/edge_applications/delete/fixtures/azion.json
@@ -1,0 +1,22 @@
+{
+    "name": "testdelete",
+    "type": "javascript",
+    "env": "production",
+    "function": {
+      "id": 123,
+      "name": "__DEFAULT__",
+      "file": "./worker/function.js",
+      "args": "./azion/args.json"
+    },
+    "application": {
+      "id": 666,
+      "name": "__DEFAULT__"
+    },
+    "domain": {
+      "id": 42069,
+      "name": "__DEFAULT__"
+    },
+    "rt-purge": {
+      "purge_on_publish": true
+    }
+  }

--- a/pkg/cmd/edge_applications/update/update.go
+++ b/pkg/cmd/edge_applications/update/update.go
@@ -73,7 +73,6 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 				}
 				err = cmdutil.UnmarshallJsonFromReader(file, &request)
 				if err != nil {
-					fmt.Println(err)
 					return utils.ErrorUnmarshalReader
 				}
 			} else {

--- a/utils/helpers.go
+++ b/utils/helpers.go
@@ -120,10 +120,15 @@ func GetAzionJsonContent() (*contracts.AzionApplicationOptions, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	_, err = os.Stat(path + "/azion/azion.json")
+	if err != nil {
+		return nil, err
+	}
+
 	jsonConf := path + "/azion/azion.json"
 	file, err := os.ReadFile(jsonConf)
 	if err != nil {
-		fmt.Println(&jsonConf)
 		return nil, ErrorOpeningAzionJsonFile
 	}
 


### PR DESCRIPTION
**WHAT**
- Add `--cascade` flag to delete command (edge_applications); 
- Unit tests;
- Code refactoring.

Cascade delete:
This PR adds the following: deleting everything that it's created by the publish command. This deletion is based on the azion.json file, since it is also what we use in the publish command. 