### PR TITLE
chore: remove active flag from edge_applications update

### DIFF
--- a/messages/edge_applications/messages.go
+++ b/messages/edge_applications/messages.go
@@ -111,7 +111,6 @@ var (
 	EdgeApplicationUpdateFlagLoadBalancer            = "Whether the Edge Application has Load Balancer active or not"
 	EdgeApplicationUpdateRawLogs                     = "Whether the Edge Application has Raw Logs active or not"
 	EdgeApplicationUpdateWebApplicationFirewall      = "Whether the Edge Application has Web Application Firewall active or not"
-	EdgeApplicationUpdateFlagActive                  = "Whether the Edge Application should be active or not"
 	EdgeApplicationUpdateFlagIn                      = "Given path and JSON file to automatically update the Edge Application attributes; you can use - for reading from stdin"
 	EdgeApplicationUpdateOutputSuccess               = "Updated Edge Application with ID %d\n"
 	EdgeApplicationUpdateHelpFlag                    = "Displays more information about the update subcommand"

--- a/pkg/cmd/edge_applications/update/update.go
+++ b/pkg/cmd/edge_applications/update/update.go
@@ -99,14 +99,6 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 					request.SetMinimumTlsVersion(fields.MinimumTlsVersion)
 				}
 
-				if cmd.Flags().Changed("active") {
-					active, err := strconv.ParseBool(fields.Active)
-					if err != nil {
-						return fmt.Errorf("%w: %q", msg.ErrorActiveFlag, fields.Active)
-					}
-					request.SetActive(active)
-				}
-
 				if cmd.Flags().Changed("application-acceleration") {
 					converted, err := strconv.ParseBool(fields.ApplicationAcceleration)
 					if err != nil {
@@ -195,7 +187,7 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 			response, err := client.Update(ctx, &request)
 
 			if err != nil {
-				return fmt.Errorf(msg.ErrorUpdateFunction.Error(), err)
+				return fmt.Errorf(msg.ErrorUpdateApplication.Error(), err)
 			}
 
 			fmt.Fprintf(f.IOStreams.Out, "Updated Edge Application with ID %d\n", response.GetId())
@@ -211,7 +203,6 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 	flags.Int64Var(&fields.HttpPort, "http-port", 80, msg.EdgeApplicationUpdateFlagHttpPort)
 	flags.Int64Var(&fields.HttpsPort, "https-port", 443, msg.EdgeApplicationUpdateFlagHttpsPort)
 	flags.StringVar(&fields.MinimumTlsVersion, "min-tsl-ver", "", msg.EdgeApplicationUpdateFlagMinimumTlsVersion)
-	flags.StringVar(&fields.Active, "active", "", msg.EdgeApplicationUpdateFlagActive)
 	flags.StringVar(&fields.ApplicationAcceleration, "application-acceleration", "", msg.EdgeApplicationUpdateFlagApplicationAcceleration)
 	flags.StringVar(&fields.Caching, "caching", "", msg.EdgeApplicationUpdateFlagCaching)
 	flags.StringVar(&fields.DeviceDetection, "device-detection", "", msg.EdgeApplicationUpdateFlagDeviceDetection)


### PR DESCRIPTION
**WHAT**
- Remove --active flag, because we can never change it;
- Update message to say Edge Application instead of Edge Function.