### PR TITLE
chore: many small fixes to domain command tree

### DIFF
--- a/messages/domains/errors.go
+++ b/messages/domains/errors.go
@@ -3,12 +3,12 @@ package domains
 import "errors"
 
 var (
-	ErrorMandatoryCreateFlags    = errors.New("A mandatory flag is missing. You must provide --name --application-id flags when the --in flag is not provided. Run the command 'azion cli edge_functions create --help' to display more information and try again.")
-	ErrorActiveFlag              = errors.New("Invalid --active flag provided. The flag must have  'true' or 'false' values. Run the command 'azioncli edge_functions <subcommand> --help' to display more information and try again.")
+	ErrorMandatoryCreateFlags    = errors.New("A mandatory flag is missing. You must provide --name and --application-id flags when the --in flag is not provided. Run the command 'azioncli domains create --help' to display more information and try again.")
+	ErrorActiveFlag              = errors.New("Invalid --active flag provided. The flag must have  'true' or 'false' values. Run the command 'azioncli domains <subcommand> --help' to display more information and try again.")
 	ErrorMissingDomainIdArgument = errors.New("The flag '--domain-id' must be informed. Please, inform the correct id and try again or run the command ‘azioncli domains <subcommand> --help’ to display more information and try again. ")
-	ErrorCreateDomain            = errors.New("Failed to create the Domain: [API Response Body]. Check your settings and try again. If the error persists, contact Azion support.")
+	ErrorCreateDomain            = errors.New("Failed to create the Domain: %s. Check your settings and try again. If the error persists, contact Azion support.")
 	ErrorGetDomains              = errors.New("Failed to list your domains. Check your settings and try again. If the error persists, contact Azion support.")
-	ErrorUpdateDomain            = errors.New("Failed to update the Domain: [API Response Body]. Check your settings and try again. If the error persists, contact Azion support.")
+	ErrorUpdateDomain            = errors.New("Failed to update the Domain: %s. Check your settings and try again. If the error persists, contact Azion support.")
 
 	//used by more than one cmd
 	DomainsFlagId                      = "Unique identifier of the Domain"
@@ -17,6 +17,6 @@ var (
 	ErrorGetDomain                     = errors.New("Failed to describe the domain. Check your settings and try again. If the error persists, contact Azion support.")
 	ErrorMissingDomainIdArgumentDelete = errors.New("A mandatory flag is missing. You must provide a domain_id as an argument. Run the command 'azioncli domains <subcommand> --help' to display more information and try again")
 	ErrorFailToDeleteDomain            = errors.New("Failed to delete the Domain: %s. Check your settings and try again. If the error persists, contact Azion support")
-  ErrorMissingCnames                 = errors.New("Missing Cnames. When the flag '--cname-access-only`is set as 'true', at least one CNAME must be provided through the flag '--cnames'. Add one or more CNAMES, or set '--cname-access-only' as false and try again.")
+	ErrorMissingCnames                 = errors.New("Missing Cnames. When the flag '--cname-access-only`is set as 'true', at least one CNAME must be provided through the flag '--cnames'. Add one or more CNAMES, or set '--cname-access-only' as false and try again.")
 	ErrorDigitalCertificateFlag        = errors.New("Invalid --digital-certificate-id flag provided. The flag must have an Integer or 'null' as a value. Run the command 'azioncli domains <subcommand> --help' to display more information and try again")
 )

--- a/pkg/api/domains/domains.go
+++ b/pkg/api/domains/domains.go
@@ -27,7 +27,12 @@ type UpdateRequest struct {
 
 type DomainResponse interface {
 	GetId() int64
+	GetName() string
 	GetDomainName() string
+	GetCnames() []string
+	GetCnameAccessOnly() bool
+	GetDigitalCertificateId() int64
+	GetEdgeApplicationId() int64
 }
 
 func NewClient(c *http.Client, url string, token string) *Client {

--- a/pkg/cmd/domains/create/create.go
+++ b/pkg/cmd/domains/create/create.go
@@ -16,7 +16,7 @@ import (
 )
 
 type Fields struct {
-	Name                 string  `json:"name"`
+	Name                 string   `json:"name"`
 	Cnames               []string `json:"cnames,omitempty"`
 	EdgeApplicationId    int      `json:"edge_application_id"`
 	DigitalCertificateId int      `json:"digital_certificate_id,omitempty"`
@@ -40,15 +40,10 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
         $ azioncli domains create --in "create.json"
         `),
 		RunE: func(cmd *cobra.Command, args []string) error {
-      
-      // flags requireds
-      if !cmd.Flags().Changed("name") && !cmd.Flags().Changed("application-id") && !cmd.Flags().Changed("in") {
-				return msg.ErrorMissingApplicationIdArgument
-			}
 
-      request := new(api.CreateRequest)
+			request := new(api.CreateRequest)
 			if cmd.Flags().Changed("in") {
-        var (
+				var (
 					file *os.File
 					err  error
 				)
@@ -64,21 +59,27 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 				if err != nil {
 					return utils.ErrorUnmarshalReader
 				}
-      } else {
-        if fields.CnameAccessOnly {
-          if len(fields.Cnames) < 1 {
-            return msg.ErrorMissingCnames
-          }
-        }
+			} else {
+				// flags requireds
+				if !cmd.Flags().Changed("name") || !cmd.Flags().Changed("application-id") {
+					return msg.ErrorMandatoryCreateFlags
+				}
 
-			  request.SetName(fields.Name)
-			  request.SetCnames(fields.Cnames)
-			  request.SetEdgeApplicationId(int64(fields.EdgeApplicationId))
-			  if fields.DigitalCertificateId > 0 {
-          request.SetDigitalCertificateId(int64(fields.DigitalCertificateId))
-			  }
-			  request.SetIsActive(fields.IsActive) 
-      }
+				if fields.CnameAccessOnly {
+					if len(fields.Cnames) < 1 {
+						return msg.ErrorMissingCnames
+					}
+				}
+
+				request.SetCnameAccessOnly(fields.CnameAccessOnly)
+				request.SetName(fields.Name)
+				request.SetCnames(fields.Cnames)
+				request.SetEdgeApplicationId(int64(fields.EdgeApplicationId))
+				if fields.DigitalCertificateId > 0 {
+					request.SetDigitalCertificateId(int64(fields.DigitalCertificateId))
+				}
+				request.SetIsActive(fields.IsActive)
+			}
 
 			client := api.NewClient(f.HttpClient, f.Config.GetString("api_url"), f.Config.GetString("token"))
 			response, err := client.Create(context.Background(), request)
@@ -95,7 +96,7 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 	flags.StringSliceVar(&fields.Cnames, "cnames", []string{}, msg.DomainsCreateFlagCnames)
 	flags.BoolVar(&fields.CnameAccessOnly, "cname-access-only", false, msg.DomainsCreateFlagCnameAccessOnly)
 	flags.IntVarP(&fields.DigitalCertificateId, "digital-certificate-id", "d", 0, msg.DomainsCreateFlagDigitalCertificateId)
-  flags.IntVarP(&fields.EdgeApplicationId, "application-id", "e", 0, msg.DomainsCreateFlagEdgeApplicationId)
+	flags.IntVarP(&fields.EdgeApplicationId, "application-id", "a", 0, msg.DomainsCreateFlagEdgeApplicationId)
 	flags.BoolVar(&fields.IsActive, "active", true, msg.DomainsCreateFlagIsActive)
 	flags.StringVar(&fields.Path, "in", "", msg.DomainsCreateFlagIn)
 	flags.BoolP("help", "h", false, msg.DomainsCreateHelpFlag)

--- a/pkg/cmd/domains/create/create.go
+++ b/pkg/cmd/domains/create/create.go
@@ -16,13 +16,13 @@ import (
 )
 
 type Fields struct {
-	Name                 string   `json:"name"`
-	Cnames               []string `json:"cnames,omitempty"`
-	EdgeApplicationId    int      `json:"edge_application_id"`
-	DigitalCertificateId int      `json:"digital_certificate_id,omitempty"`
-	CnameAccessOnly      bool     `json:"cname_access-only,omitempty"`
-	IsActive             bool     `json:"is_active,omitempty"`
-	Path                 string   `json:"path,omitempty"`
+	Name                 string
+	Cnames               []string
+	EdgeApplicationId    int
+	DigitalCertificateId int
+	CnameAccessOnly      bool
+	IsActive             bool
+	Path                 string
 }
 
 func NewCmd(f *cmdutil.Factory) *cobra.Command {

--- a/pkg/cmd/domains/describe/describe.go
+++ b/pkg/cmd/domains/describe/describe.go
@@ -90,8 +90,19 @@ func format(cmd *cobra.Command, domain api.DomainResponse) ([]byte, error) {
 		}
 		return file, nil
 	} else {
-		b.Write([]byte(fmt.Sprintf("ID: %d\n", uint64(domain.GetId()))))
-		b.Write([]byte(fmt.Sprintf("Name: %s\n", domain.GetDomainName())))
+		b.Write([]byte(fmt.Sprintf("ID: %d\n", domain.GetId())))
+		b.Write([]byte(fmt.Sprintf("Name: %s\n", domain.GetName())))
+		b.Write([]byte(fmt.Sprintf("Domain: %s\n", domain.GetDomainName())))
+		b.Write([]byte(fmt.Sprintf("Cname Access Only: %t\n", domain.GetCnameAccessOnly())))
+		if domain.GetCnameAccessOnly() {
+			Cnames := domain.GetCnames()
+			b.Write([]byte("Cnames:\n"))
+			for _, cname := range Cnames {
+				b.Write([]byte(fmt.Sprintf("%s\n", cname)))
+			}
+		}
+		b.Write([]byte(fmt.Sprintf("Application ID: %d\n", domain.GetEdgeApplicationId())))
+		b.Write([]byte(fmt.Sprintf("Digital Certificate ID: %d\n", domain.GetDigitalCertificateId())))
 		return b.Bytes(), nil
 	}
 }

--- a/pkg/cmd/domains/describe/describe_test.go
+++ b/pkg/cmd/domains/describe/describe_test.go
@@ -16,7 +16,7 @@ func TestDescribe(t *testing.T) {
 		mock := &httpmock.Registry{}
 
 		mock.Register(
-			httpmock.REST("GET", "domains/878"),
+			httpmock.REST("GET", "domains/1675272891"),
 			httpmock.JSONFromFile("./fixtures/domain.json"),
 		)
 
@@ -24,12 +24,12 @@ func TestDescribe(t *testing.T) {
 
 		cmd := NewCmd(f)
 
-		cmd.SetArgs([]string{"-d", "878"})
+		cmd.SetArgs([]string{"-d", "1675272891"})
 
 		err := cmd.Execute()
 		require.NoError(t, err)
 
-		require.Equal(t, "ID: 878\nName: oda1ssad1f1.map.azionedge.net\n", stdout.String())
+		require.Equal(t, "ID: 1675272891\nName: Valideishoun\nDomain: oda1ssad1f1.map.azionedge.net\nCname Access Only: false\nApplication ID: 1674767911\nDigital Certificate ID: 0\n", stdout.String())
 	})
 	t.Run("not found", func(t *testing.T) {
 		mock := &httpmock.Registry{}

--- a/pkg/cmd/domains/describe/fixtures/domain.json
+++ b/pkg/cmd/domains/describe/fixtures/domain.json
@@ -1,13 +1,11 @@
 {
     "results": {
-        "id": 878,
-        "name": "asdfasdf",
-        "cnames": [
-            "asdfasdf.com"
-        ],
-        "cname_access_only": true,
+        "id": 1675272891,
+        "name": "Valideishoun",
+        "cnames": [],
+        "cname_access_only": false,
         "digital_certificate_id": null,
-        "edge_application_id": 123213 ,
+        "edge_application_id": 1674767911 ,
         "is_active": true,
         "domain_name": "oda1ssad1f1.map.azionedge.net"
     },


### PR DESCRIPTION
**WHAT**
- Correct error returned when mandatory flags are not sent;
- Fix message to format json body into error;
- Change functions to domains;
- Check mandatory flags only if --in is not sent;
- Domains Describe now shows more fields;
- Remove unnecessary json fields in structure.