### PR TITLE
feat: add describe command to device groups

### DIFF
--- a/messages/device_groups/errors.go
+++ b/messages/device_groups/errors.go
@@ -7,6 +7,7 @@ import (
 var (
 	ErrorMissingApplicationIDArgument = errors.New("A mandatory flag is missing. You must provide a application-id as an argument or path to import the file. Run the command 'azioncli domains <subcommand> --help' to display more information and try again")
 	ErrorGetDeviceGroups              = errors.New("Failed to describe the device groups: %s. Check your settings and try again. If the error persists, contact Azion support.")
-	ErrorMandatoryFlags = errors.New("One or more required flags are missing. You must provide the --application-id and --group-id flags. Run the command 'azioncli rules_engine <subcommand> --help' to display more information and try again.")
-	ErrorFailToDelete   = errors.New("Failed to delete the rule in Rules Engine: %s. Check your settings and try again. If the error persists, contact Azion support.")
+	ErrorListDeviceGroups             = errors.New("Failed to list your rules in Rules Engine: %s. Check your settings and try again. If the error persists, contact Azion support.")
+	ErrorMandatoryFlags               = errors.New("One or more required flags are missing. You must provide the --application-id and --group-id flags. Run the command 'azioncli rules_engine <subcommand> --help' to display more information and try again.")
+	ErrorFailToDelete                 = errors.New("Failed to delete the rule in Rules Engine: %s. Check your settings and try again. If the error persists, contact Azion support.")
 )

--- a/messages/device_groups/messages.go
+++ b/messages/device_groups/messages.go
@@ -20,7 +20,16 @@ var (
 	DeviceGroupsDeleteLongDescription  = "Deletes a Device Group based on the given '--group-id' and '--application-id'"
 	DeviceGroupsDeleteOutputSuccess    = "Device Group %d was successfully deleted\n"
 	DeviceGroupsDeleteHelpFlag         = "Displays more information about the delete subcommand"
-  
-  ApplicationFlagId = "Unique identifier for the edge application that implements this Device Group. The '--application-id' flag is required"
+
+	//describe cmd
+	DeviceGroupsDescribeUsage            = "describe --application-id <application_id> --group-id <group_id> [flags]"
+	DeviceGroupsDescribeShortDescription = "Returns the information related to the Device Group"
+	DeviceGroupsDescribeLongDescription  = "Returns the information related to the Device Group, informed through the flag '--group-id' in detail"
+	DeviceGroupsDescribeFlagOut          = "Exports the output of the subcommand 'describe' to the given file path <file_path/file_name.ext>"
+	DeviceGroupsDescribeFlagFormat       = "Changes the output format passing the json value to the flag. Example '--format json'"
+	DeviceGroupsDescribeHelpFlag         = "Displays more information about the describe subcommand"
+	DeviceGroupsFileWritten              = "File successfully written to: %s\n"
+
+	ApplicationFlagId = "Unique identifier for the edge application that implements this Device Group. The '--application-id' flag is required"
 	DeviceGroupFlagId = "Unique identifier for a Device Group. The '--group-id' flag is required"
 )

--- a/pkg/api/edge_applications/edge_applications.go
+++ b/pkg/api/edge_applications/edge_applications.go
@@ -62,6 +62,12 @@ type RulesEngineResponse interface {
 	GetName() string
 }
 
+type DeviceGroupsResponse interface {
+	GetId() int64
+	GetName() string
+	GetUserAgent() string
+}
+
 type Client struct {
 	apiClient *sdk.APIClient
 }
@@ -505,4 +511,12 @@ func (c *Client) DeleteDeviceGroup(ctx context.Context, appID int64, groupID int
 	}
 
 	return nil
+}
+
+func (c *Client) GetDeviceGroups(ctx context.Context, edgeApplicationID, groupID int64) (DeviceGroupsResponse, error) {
+	resp, httpResp, err := c.apiClient.EdgeApplicationsDeviceGroupsApi.EdgeApplicationsEdgeApplicationIdDeviceGroupsDeviceGroupIdGet(ctx, edgeApplicationID, groupID).Execute()
+	if err != nil {
+		return nil, utils.ErrorPerStatusCode(httpResp, err)
+	}
+	return &resp.Results, nil
 }

--- a/pkg/cmd/device_groups/describe/describe.go
+++ b/pkg/cmd/device_groups/describe/describe.go
@@ -1,0 +1,100 @@
+package describe
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+
+	"github.com/fatih/color"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/MaxwelMazur/tablecli"
+	msg "github.com/aziontech/azion-cli/messages/device_groups"
+
+	api "github.com/aziontech/azion-cli/pkg/api/edge_applications"
+	"github.com/aziontech/azion-cli/pkg/cmdutil"
+	"github.com/aziontech/azion-cli/pkg/contracts"
+	"github.com/aziontech/azion-cli/utils"
+	"github.com/spf13/cobra"
+)
+
+var (
+	applicationID int64
+	groupID       int64
+)
+
+func NewCmd(f *cmdutil.Factory) *cobra.Command {
+	opts := &contracts.DescribeOptions{}
+	cmd := &cobra.Command{
+		Use:           msg.DeviceGroupsDescribeUsage,
+		Short:         msg.DeviceGroupsDescribeShortDescription,
+		Long:          msg.DeviceGroupsDescribeLongDescription,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		Example: heredoc.Doc(`
+      $ azioncli device_groups describe --application-id 1673635839 --group-id 31223
+      $ azioncli device_groups describe -a 1673635839 -g 31223 --format json
+      $ azioncli device_groups describe --application-id 1673635839 --group-id 31223 --out "./tmp/test.json"
+    `),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !cmd.Flags().Changed("application-id") || !cmd.Flags().Changed("group-id") {
+				return msg.ErrorMandatoryFlags
+			}
+
+			client := api.NewClient(f.HttpClient, f.Config.GetString("api_url"), f.Config.GetString("token"))
+			ctx := context.Background()
+			groups, err := client.GetDeviceGroups(ctx, applicationID, groupID)
+			if err != nil {
+				return fmt.Errorf(msg.ErrorGetDeviceGroups.Error(), err)
+			}
+
+			out := f.IOStreams.Out
+			formattedFuction, err := format(cmd, groups)
+			if err != nil {
+				return utils.ErrorFormatOut
+			}
+
+			if cmd.Flags().Changed("out") {
+				err := cmdutil.WriteDetailsToFile(formattedFuction, opts.OutPath, out)
+				if err != nil {
+					return fmt.Errorf("%s: %w", utils.ErrorWriteFile, err)
+				}
+				fmt.Fprintf(out, msg.DeviceGroupsFileWritten, filepath.Clean(opts.OutPath))
+			} else {
+				_, err := out.Write(formattedFuction[:])
+				if err != nil {
+					return err
+				}
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().Int64VarP(&applicationID, "application-id", "a", 0, msg.ApplicationFlagId)
+	cmd.Flags().Int64VarP(&groupID, "group-id", "g", 0, msg.DeviceGroupFlagId)
+	cmd.Flags().StringVar(&opts.OutPath, "out", "", msg.DeviceGroupsDescribeFlagOut)
+	cmd.Flags().StringVar(&opts.Format, "format", "", msg.DeviceGroupsDescribeFlagFormat)
+	cmd.Flags().BoolP("help", "h", false, msg.DeviceGroupsDescribeHelpFlag)
+
+	return cmd
+}
+
+func format(cmd *cobra.Command, rules api.DeviceGroupsResponse) ([]byte, error) {
+	format, err := cmd.Flags().GetString("format")
+	if err != nil {
+		return nil, err
+	}
+
+	if format == "json" || cmd.Flags().Changed("out") {
+		return json.MarshalIndent(rules, "", " ")
+	}
+
+	tbl := tablecli.New("", "")
+	tbl.WithFirstColumnFormatter(color.New(color.FgGreen).SprintfFunc())
+	tbl.AddRow("Device Group ID: ", rules.GetId())
+	tbl.AddRow("Name: ", rules.GetName())
+	tbl.AddRow("User Agent: ", rules.GetUserAgent())
+	return tbl.GetByteFormat(), nil
+}

--- a/pkg/cmd/device_groups/describe/describe_test.go
+++ b/pkg/cmd/device_groups/describe/describe_test.go
@@ -6,25 +6,25 @@ import (
 	"os"
 	"testing"
 
-	msg "github.com/aziontech/azion-cli/messages/rules_engine"
+	msg "github.com/aziontech/azion-cli/messages/device_groups"
 	"github.com/aziontech/azion-cli/pkg/httpmock"
 	"github.com/aziontech/azion-cli/pkg/testutils"
 	"github.com/stretchr/testify/require"
 )
 
 func TestDescribe(t *testing.T) {
-	t.Run("describe a rule engine", func(t *testing.T) {
+	t.Run("describe a device group", func(t *testing.T) {
 		mock := &httpmock.Registry{}
 
 		mock.Register(
-			httpmock.REST("GET", "edge_applications/1678743802/rules_engine/request/rules/173617"),
-			httpmock.JSONFromFile("./fixtures/rules.json"),
+			httpmock.REST("GET", "edge_applications/1676400693/device_groups/2259"),
+			httpmock.JSONFromFile("./fixtures/groups.json"),
 		)
 
 		f, _, _ := testutils.NewFactory(mock)
 
 		cmd := NewCmd(f)
-		cmd.SetArgs([]string{"-a", "1678743802", "-r", "173617", "-p", "request"})
+		cmd.SetArgs([]string{"-a", "1676400693", "-g", "2259"})
 
 		err := cmd.Execute()
 		require.NoError(t, err)
@@ -33,7 +33,7 @@ func TestDescribe(t *testing.T) {
 		mock := &httpmock.Registry{}
 
 		mock.Register(
-			httpmock.REST("GET", "edge_applications/1678743802/rules_engine/request/rules/666"),
+			httpmock.REST("GET", "edge_applications/1676400693/device_groups/666"),
 			httpmock.StatusStringResponse(http.StatusNotFound, "Not Found"),
 		)
 
@@ -48,7 +48,7 @@ func TestDescribe(t *testing.T) {
 	t.Run("missing mandatory flag", func(t *testing.T) {
 		mock := &httpmock.Registry{}
 		mock.Register(
-			httpmock.REST("GET", "edge_applications/1678743802/rules_engine/request/rules/1"),
+			httpmock.REST("GET", "edge_applications/1676400693/device_groups/2259"),
 			httpmock.StatusStringResponse(http.StatusNotFound, "Not Found"),
 		)
 
@@ -64,15 +64,15 @@ func TestDescribe(t *testing.T) {
 		mock := &httpmock.Registry{}
 
 		mock.Register(
-			httpmock.REST("GET", "edge_applications/1678743802/rules_engine/request/rules/173617"),
-			httpmock.JSONFromFile("./fixtures/rules.json"),
+			httpmock.REST("GET", "edge_applications/1676400693/device_groups/2259"),
+			httpmock.JSONFromFile("./fixtures/groups.json"),
 		)
 
 		f, stdout, _ := testutils.NewFactory(mock)
 
 		cmd := NewCmd(f)
 		path := "./out.json"
-		cmd.SetArgs([]string{"-a", "1678743802", "-r", "173617", "-p", "request", "--out", path})
+		cmd.SetArgs([]string{"-a", "1676400693", "-g", "2259", "--out", path})
 
 		err := cmd.Execute()
 		if err != nil {

--- a/pkg/cmd/device_groups/describe/fixtures/groups.json
+++ b/pkg/cmd/device_groups/describe/fixtures/groups.json
@@ -1,0 +1,8 @@
+{
+    "results": {
+      "id": 2259,
+      "name": "test",
+      "user_agent": "Mobile|iP(hone|od)|BlackBerry|IEMobile"
+    },
+    "schema_version": 3
+  }

--- a/pkg/cmd/device_groups/device_groups.go
+++ b/pkg/cmd/device_groups/device_groups.go
@@ -3,8 +3,9 @@ package device_groups
 import (
 	"github.com/MakeNowJust/heredoc"
 	msg "github.com/aziontech/azion-cli/messages/device_groups"
-	"github.com/aziontech/azion-cli/pkg/cmd/device_groups/list"
 	"github.com/aziontech/azion-cli/pkg/cmd/device_groups/delete"
+	"github.com/aziontech/azion-cli/pkg/cmd/device_groups/describe"
+	"github.com/aziontech/azion-cli/pkg/cmd/device_groups/list"
 	"github.com/aziontech/azion-cli/pkg/cmdutil"
 	"github.com/spf13/cobra"
 )
@@ -23,7 +24,9 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 	}
 
 	deviceGroupsCmd.AddCommand(list.NewCmd(f))
-  deviceGroupsCmd.AddCommand(delete.NewCmd(f))
+	deviceGroupsCmd.AddCommand(delete.NewCmd(f))
+	deviceGroupsCmd.AddCommand(describe.NewCmd(f))
+
 	deviceGroupsCmd.Flags().BoolP("help", "h", false, msg.DeviceGroupsFlagHelp)
 	return deviceGroupsCmd
 }

--- a/pkg/cmd/device_groups/list/list.go
+++ b/pkg/cmd/device_groups/list/list.go
@@ -45,7 +45,7 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 						return nil
 					}
 					if err != nil {
-						return fmt.Errorf(msg.ErrorGetDeviceGroups.Error(), err)
+						return fmt.Errorf(msg.ErrorListDeviceGroups.Error(), err)
 					}
 				}
 			}

--- a/pkg/cmd/edge_applications/build/build.go
+++ b/pkg/cmd/edge_applications/build/build.go
@@ -67,7 +67,7 @@ func newBuildCmd(f *cmdutil.Factory) *BuildCmd {
 			return utils.RunCommandWithOutput(envs, cmd)
 		},
 		CommandRunnerStream: func(out io.Writer, cmd string, envs []string) error {
-			return utils.RunCommandSteamOutput(f.IOStreams.Out, envs, cmd)
+			return utils.RunCommandStreamOutput(f.IOStreams.Out, envs, cmd)
 		},
 		ConfigRelativePath: "/azion/config.json",
 		GetWorkDir:         utils.GetWorkingDir,

--- a/pkg/cmd/edge_applications/build/build.go
+++ b/pkg/cmd/edge_applications/build/build.go
@@ -3,6 +3,7 @@ package build
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"strings"
@@ -21,16 +22,17 @@ import (
 )
 
 type BuildCmd struct {
-	Io                 *iostreams.IOStreams
-	WriteFile          func(filename string, data []byte, perm fs.FileMode) error
-	CommandRunner      func(cmd string, envvars []string) (string, int, error)
-	FileReader         func(path string) ([]byte, error)
-	ConfigRelativePath string
-	GetWorkDir         func() (string, error)
-	EnvLoader          func(path string) ([]string, error)
-	Stat               func(path string) (fs.FileInfo, error)
-	VersionId          func(dir string) (string, error)
-	f                  *cmdutil.Factory
+	Io                  *iostreams.IOStreams
+	WriteFile           func(filename string, data []byte, perm fs.FileMode) error
+	CommandRunner       func(cmd string, envvars []string) (string, int, error)
+	CommandRunnerStream func(out io.Writer, cmd string, envvars []string) error
+	FileReader          func(path string) ([]byte, error)
+	ConfigRelativePath  string
+	GetWorkDir          func() (string, error)
+	EnvLoader           func(path string) ([]string, error)
+	Stat                func(path string) (fs.FileInfo, error)
+	VersionId           func(dir string) (string, error)
+	f                   *cmdutil.Factory
 }
 
 func NewCmd(f *cmdutil.Factory) *cobra.Command {
@@ -63,6 +65,9 @@ func newBuildCmd(f *cmdutil.Factory) *BuildCmd {
 		FileReader: os.ReadFile,
 		CommandRunner: func(cmd string, envs []string) (string, int, error) {
 			return utils.RunCommandWithOutput(envs, cmd)
+		},
+		CommandRunnerStream: func(out io.Writer, cmd string, envs []string) error {
+			return utils.RunCommandSteamOutput(f.IOStreams.Out, envs, cmd)
 		},
 		ConfigRelativePath: "/azion/config.json",
 		GetWorkDir:         utils.GetWorkingDir,
@@ -221,13 +226,10 @@ func runCommand(cmd *BuildCmd, conf *contracts.AzionApplicationConfig) error {
 		fmt.Fprintf(cmd.Io.Out, msg.EdgeApplicationsBuildRunningCmd)
 		fmt.Fprintf(cmd.Io.Out, "$ %s\n", command)
 
-		output, _, err := cmd.CommandRunner(command, []string{})
+		err := cmd.CommandRunnerStream(cmd.Io.Out, command, []string{})
 		if err != nil {
-			fmt.Fprintf(cmd.Io.Out, "%s\n", output)
 			return msg.ErrFailedToRunBuildCommand
 		}
-
-		fmt.Fprintf(cmd.Io.Out, "%s\n", output)
 
 	case "on-error":
 		output, exitCode, err := cmd.CommandRunner(command, []string{})

--- a/pkg/cmd/edge_applications/build/build_test.go
+++ b/pkg/cmd/edge_applications/build/build_test.go
@@ -3,6 +3,7 @@ package build
 import (
 	"bytes"
 	"errors"
+	"io"
 	"io/fs"
 	"os"
 	"testing"
@@ -82,8 +83,9 @@ func TestBuild(t *testing.T) {
 		command.FileReader = func(path string) ([]byte, error) {
 			return jsonContent.Bytes(), nil
 		}
-		command.CommandRunner = func(cmd string, envs []string) (string, int, error) {
-			return "Command output goes here", 42, expectedErr
+		command.CommandRunnerStream = func(out io.Writer, cmd string, envvars []string) error {
+			return expectedErr
+
 		}
 		command.EnvLoader = func(path string) ([]string, error) {
 			return envVars, nil

--- a/pkg/cmd/edge_functions_instances/delete/delete.go
+++ b/pkg/cmd/edge_functions_instances/delete/delete.go
@@ -22,8 +22,8 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		Example: heredoc.Doc(`
-		  $ azioncli edge_functions_instances delete --application-id 1234 --instance-id 12312
-		  $ azioncli edge_functions_instances delete -a 1234 -i 12312
+		  $ azioncli edge_functions_instances delete --application-id 1673635839 --instance-id 12312
+		  $ azioncli edge_functions_instances delete -a 1673635839 -i 12312
     `),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if !cmd.Flags().Changed("application-id") || !cmd.Flags().Changed("instance-id") {

--- a/pkg/cmd/origins/delete/delete.go
+++ b/pkg/cmd/origins/delete/delete.go
@@ -21,8 +21,8 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		Example: heredoc.Doc(`
-		  $ azioncli origins delete --application-id 1234 --origin-key 03a6e7bf-8e26-49c7-a66e-ab8eaa425086
-		  $ azioncli origins delete -a 1234 -o 03a6e7bf-8e26-49c7-a66e-ab8eaa425086
+		  $ azioncli origins delete --application-id 1673635839 --origin-key 03a6e7bf-8e26-49c7-a66e-ab8eaa425086
+		  $ azioncli origins delete -a 1673635839 -o 03a6e7bf-8e26-49c7-a66e-ab8eaa425086
     `),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if !cmd.Flags().Changed("application-id") || !cmd.Flags().Changed("origin-key") {

--- a/pkg/cmd/origins/describe/describe.go
+++ b/pkg/cmd/origins/describe/describe.go
@@ -34,9 +34,9 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		Example: heredoc.Doc(`
-      $ azioncli origins describe --application-id 4312 --origin-id 31223
-      $ azioncli origins describe --application-id 1337 --origin-id 31223--format json
-      $ azioncli origins describe --application-id 1337 --origin-id 31223--out "./tmp/test.json" --format json
+      $ azioncli origins describe --application-id 1673635839 --origin-id 31223
+      $ azioncli origins describe --application-id 1673635839 --origin-id 31223--format json
+      $ azioncli origins describe --application-id 1673635839 --origin-id 31223--out "./tmp/test.json" --format json
     `),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if !cmd.Flags().Changed("application-id") || !cmd.Flags().Changed("origin-id") {
@@ -47,7 +47,7 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 			ctx := context.Background()
 			origin, err := client.GetOrigin(ctx, applicationID, originID)
 			if err != nil {
-                return fmt.Errorf(msg.ErrorGetOrigin.Error(), err)
+				return fmt.Errorf(msg.ErrorGetOrigin.Error(), err)
 			}
 
 			out := f.IOStreams.Out

--- a/pkg/cmd/rules_engine/delete/delete.go
+++ b/pkg/cmd/rules_engine/delete/delete.go
@@ -22,8 +22,8 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		Example: heredoc.Doc(`
-		  $ azioncli rules_engine delete --application-id 1234 --rule-id 12312
-		  $ azioncli rules_engine delete -a 1234 -r 12312
+		  $ azioncli rules_engine delete --application-id 1673635839 --rule-id 12312
+		  $ azioncli rules_engine delete -a 1673635839 -r 12312
     `),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if !cmd.Flags().Changed("application-id") || !cmd.Flags().Changed("phase") || !cmd.Flags().Changed("rule-id") {

--- a/pkg/cmd/rules_engine/describe/describe.go
+++ b/pkg/cmd/rules_engine/describe/describe.go
@@ -34,9 +34,9 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		Example: heredoc.Doc(`
-      $ azioncli rules_engine describe --application-id 4312 --rule-id 31223 --phase request
-      $ azioncli rules_engine describe --application-id 1337 --rule-id 31223 --phase response --format json
-      $ azioncli rules_engine describe --application-id 1337 --rule-id 31223 --phase request --out "./tmp/test.json" --format json
+      $ azioncli rules_engine describe --application-id 1673635839 --rule-id 31223 --phase request
+      $ azioncli rules_engine describe --application-id 1673635839 --rule-id 31223 --phase response --format json
+      $ azioncli rules_engine describe --application-id 1673635839 --rule-id 31223 --phase request --out "./tmp/test.json" --format json
     `),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if !cmd.Flags().Changed("application-id") || !cmd.Flags().Changed("phase") || !cmd.Flags().Changed("rule-id") {

--- a/pkg/cmd/rules_engine/list/list.go
+++ b/pkg/cmd/rules_engine/list/list.go
@@ -27,8 +27,8 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 		Long:          msg.RulesEngineListLongDescription,
 		SilenceUsage:  true,
 		SilenceErrors: true, Example: heredoc.Doc(`
-		$ azioncli rules_engine list -a 1234 -p request
-		$ azioncli rules_engine list --application-id 1234 --phase response --details
+		$ azioncli rules_engine list -a 1673635839 -p request
+		$ azioncli rules_engine list --application-id 1673635839 --phase response --details
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if !cmd.Flags().Changed("application-id") || !cmd.Flags().Changed("phase") {

--- a/utils/errors.go
+++ b/utils/errors.go
@@ -26,6 +26,7 @@ var (
 	ErrorInvalidOption              = errors.New("You must inform 'yes' or 'no' as input, or force --yes or --no by using the flags")
 	ErrorCleaningDirectory          = errors.New("Failed to clean the directory's contents because the directory is read-only and/or isn't accessible. Change the attributes of the directory to read/write and/or give access to it")
 	ErrorRunningCommand             = errors.New("Failed to run the command specified in the template (config.json)")
+	ErrorRunningCommandStream       = errors.New("Failed to run the command specified in the template (config.json): %s")
 
 	ErrorLoadingEnvVars         = errors.New("Failed to load the edge applications's environment variables. Verify if the environment variables exist and/or if their values are valid and try again")
 	ErrorOpeningAzionJsonFile   = errors.New("Failed to open the given 'azion.json' file. Verify if the file format is JSON or fix its content according to the JSON format specification at https://www.json.org/json-en.html")

--- a/utils/helpers.go
+++ b/utils/helpers.go
@@ -93,8 +93,8 @@ func RunCommandWithOutput(envVars []string, comm string) (string, int, error) {
 	return string(out), exitCode, err
 }
 
-// RunCommandSteamOutput executes the provived command while streaming its logs (stdou+stderr) directly to terminal
-func RunCommandSteamOutput(out io.Writer, envVars []string, comm string) error {
+// RunCommandStreamOutput executes the provived command while streaming its logs (stdou+stderr) directly to terminal
+func RunCommandStreamOutput(out io.Writer, envVars []string, comm string) error {
 	command := exec.Command(shell, "-c", comm)
 	if len(envVars) > 0 {
 		command.Env = os.Environ()

--- a/utils/helpers.go
+++ b/utils/helpers.go
@@ -93,7 +93,7 @@ func RunCommandWithOutput(envVars []string, comm string) (string, int, error) {
 	return string(out), exitCode, err
 }
 
-// RunCommandStreamOutput executes the provived command while streaming its logs (stdou+stderr) directly to terminal
+// RunCommandStreamOutput executes the provived command while streaming its logs (stdout+stderr) directly to terminal
 func RunCommandStreamOutput(out io.Writer, envVars []string, comm string) error {
 	command := exec.Command(shell, "-c", comm)
 	if len(envVars) > 0 {


### PR DESCRIPTION
**WHAT**
- Add describe command to device groups;
- Unit tests;
- Command Runner with streamed logs (only when output-ctrl is disabled);
- Adjusted build command tests.