### PR TITLE
fix: remove duplicate commandas

### DIFF
--- a/pkg/cmd/device_groups/list/list.go
+++ b/pkg/cmd/device_groups/list/list.go
@@ -28,10 +28,10 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
         $ azioncli device_groups list -a 16736354321
         $ azioncli device_groups list --application-id 16736354321
         $ azioncli device_groups list --application-id 16736354321 --details
-		$ azioncli device_groups list --application-id 16736354321 --order_by "id"
-		$ azioncli device_groups list --application-id 16736354321 --page 1
-		$ azioncli device_groups list --application-id 16736354321 --page_size 5
-		$ azioncli device_groups list --application-id 16736354321 --sort "asc"
+        $ azioncli device_groups list --application-id 16736354321 --order_by "id"
+        $ azioncli device_groups list --application-id 16736354321 --page 1
+        $ azioncli device_groups list --application-id 16736354321 --page_size 5
+        $ azioncli device_groups list --application-id 16736354321 --sort "asc"
         `),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var numberPage int64 = opts.Page

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -55,12 +55,10 @@ func NewRootCmd(f *cmdutil.Factory) *cobra.Command {
 	rootCmd.AddCommand(edge_functions.NewCmd(f))
 	rootCmd.AddCommand(edge_functions_instances.NewCmd(f))
 	rootCmd.AddCommand(edge_applications.NewCmd(f))
-	rootCmd.AddCommand(device_groups.NewCmd(f))
 	rootCmd.AddCommand(domains.NewCmd(f))
 	rootCmd.AddCommand(origins.NewCmd(f))
 	rootCmd.AddCommand(rules_engine.NewCmd(f))
 	rootCmd.AddCommand(cache_settings.NewCmd(f))
-	rootCmd.AddCommand(edge_functions_instances.NewCmd(f))
 	rootCmd.AddCommand(device_groups.NewCmd(f))
 	rootCmd.Flags().BoolP("help", "h", false, msg.RootHelpFlag)
 	return rootCmd


### PR DESCRIPTION
**WHAT**
- Fix duplicate commands originating from Conflict Resolution;
- Fix alignment. 