### PR TITLE
fix: remove content-type from storage-api client

### DIFF
--- a/pkg/api/storage/storage.go
+++ b/pkg/api/storage/storage.go
@@ -21,7 +21,6 @@ func NewClient(c *http.Client, url string, token string) *Client {
 	conf := sdk.NewConfiguration()
 	conf.AddDefaultHeader("Authorization", "Token "+token)
 	conf.AddDefaultHeader("Accept", "application/json; version=3")
-	conf.AddDefaultHeader("Content-Type", "application/json")
 	conf.UserAgent = "Azion_CLI/" + version.BinVersion
 	conf.Servers = sdk.ServerConfigurations{
 		{URL: url},


### PR DESCRIPTION
**WHAT**
Remove content type from storage-api client, as the API infers the type by itself.