### PR TITLE
feat: prefix different than expected

### DIFF
--- a/pkg/upbin/update_binary.go
+++ b/pkg/upbin/update_binary.go
@@ -121,16 +121,7 @@ func latestTag(tags ReferenceIter) (tag string, err error) {
 		tagCurrent := t.Name().String() // return this format "refs/tags/0.10.0"
 
 		if !strings.Contains(tagCurrent, "dev") && !strings.Contains(tagCurrent, "beta") {
-			versionParts := strings.Split(tagCurrent, ".")
-
-			const prefix string = "refs/tags/"
-
-			major := versionParts[0][len(prefix):]
-			minor := versionParts[1]
-			patch := versionParts[2]
-
-			current, _ := strconv.Atoi(fmt.Sprintf("%s%s%s", major, minor, patch))
-
+			current, _ := strconv.Atoi(getNumbersString(tagCurrent))
 			if current > biggerVersionSoFar {
 				biggerVersionSoFar = current
 				tag = tagCurrent
@@ -141,6 +132,17 @@ func latestTag(tags ReferenceIter) (tag string, err error) {
 	})
 
 	return tag, err
+}
+
+// getNumbersString get numbers from a string
+func getNumbersString(str string) string {
+	var currentNumber string
+	for _, char := range str {
+		if unicode.IsDigit(char) {
+			currentNumber += string(char)
+		}
+	}
+	return currentNumber
 }
 
 func which(command string) (string, error) {

--- a/pkg/upbin/update_binary.go
+++ b/pkg/upbin/update_binary.go
@@ -113,17 +113,19 @@ type ReferenceIter interface {
 	ForEach(func(*plumbing.Reference) error) error
 }
 
-// latestTag return value in format refs/tags/v0.10.0
+// latestTag return value in format refs/tags/0.10.0
 func latestTag(tags ReferenceIter) (tag string, err error) {
 	var biggerVersionSoFar int = 0
 
 	err = tags.ForEach(func(t *plumbing.Reference) error {
-		tagCurrent := t.Name().String() // return this format "refs/tags/v0.10.0"
+		tagCurrent := t.Name().String() // return this format "refs/tags/0.10.0"
 
-		if !strings.Contains(tagCurrent, "dev") {
+		if !strings.Contains(tagCurrent, "dev") && !strings.Contains(tagCurrent, "beta") {
 			versionParts := strings.Split(tagCurrent, ".")
 
-			major := strings.TrimPrefix(versionParts[0], "refs/tags/v")
+			const prefix string = "refs/tags/"
+
+			major := versionParts[0][len(prefix):]
 			minor := versionParts[1]
 			patch := versionParts[2]
 

--- a/pkg/upbin/update_binary_test.go
+++ b/pkg/upbin/update_binary_test.go
@@ -59,7 +59,6 @@ func (m *MockReferenceIter) ForEach(fn func(*plumbing.Reference) error) error {
 }
 
 func TestLatestTag(t *testing.T) {
-	// Create mock references
 	refs := []*plumbing.Reference{
 		plumbing.NewReferenceFromStrings("refs/tags/0.1.0", "commit1"),
 		plumbing.NewReferenceFromStrings("refs/tags/0.2.0", "commit2"),
@@ -73,15 +72,12 @@ func TestLatestTag(t *testing.T) {
 		plumbing.NewReferenceFromStrings("refs/tags/1.1.1", "commit10"),
 	}
 
-	// Create mock reference iterator
 	mockIter := &MockReferenceIter{
 		References: refs,
 	}
 
-	// Call the function under test
 	tag, err := latestTag(mockIter)
 
-	// Assert the expected result
 	assert.NoError(t, err)
 	assert.Equal(t, "refs/tags/1.1.1", tag)
 }
@@ -98,4 +94,38 @@ func TestGetLastActivity(t *testing.T) {
 	lastActivity, err := getLastActivity()
 	assert.NoError(t, err)
 	assert.Equal(t, expectedLastActivity, lastActivity)
+}
+
+func Test_getNumbersString(t *testing.T) {
+	type args struct {
+		str string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "random",
+			args: args{"abc 123 def 456.78 ghi 9"},
+			want: "123456789",
+		},
+		{
+			name: "version",
+			args: args{"v1.0.0"},
+			want: "100",
+		},
+		{
+			name: "tag",
+			args: args{"refs/tags/1.1.1"},
+			want: "111",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getNumbersString(tt.args.str); got != tt.want {
+				t.Errorf("getNumbersString() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }

--- a/pkg/upbin/update_binary_test.go
+++ b/pkg/upbin/update_binary_test.go
@@ -61,16 +61,16 @@ func (m *MockReferenceIter) ForEach(fn func(*plumbing.Reference) error) error {
 func TestLatestTag(t *testing.T) {
 	// Create mock references
 	refs := []*plumbing.Reference{
-		plumbing.NewReferenceFromStrings("refs/tags/v0.1.0", "commit1"),
-		plumbing.NewReferenceFromStrings("refs/tags/v0.2.0", "commit2"),
-		plumbing.NewReferenceFromStrings("refs/tags/v0.3.0", "commit3"),
-		plumbing.NewReferenceFromStrings("refs/tags/v0.3.1", "commit4"),
-		plumbing.NewReferenceFromStrings("refs/tags/v0.4.0", "commit5"),
-		plumbing.NewReferenceFromStrings("refs/tags/v0.4.1", "commit6"),
-		plumbing.NewReferenceFromStrings("refs/tags/v0.4.3", "commit7"),
-		plumbing.NewReferenceFromStrings("refs/tags/v1.0.0", "commit8"),
-		plumbing.NewReferenceFromStrings("refs/tags/v1.1.0", "commit9"),
-		plumbing.NewReferenceFromStrings("refs/tags/v1.1.1", "commit10"),
+		plumbing.NewReferenceFromStrings("refs/tags/0.1.0", "commit1"),
+		plumbing.NewReferenceFromStrings("refs/tags/0.2.0", "commit2"),
+		plumbing.NewReferenceFromStrings("refs/tags/0.3.0", "commit3"),
+		plumbing.NewReferenceFromStrings("refs/tags/0.3.1", "commit4"),
+		plumbing.NewReferenceFromStrings("refs/tags/0.4.0", "commit5"),
+		plumbing.NewReferenceFromStrings("refs/tags/0.4.1", "commit6"),
+		plumbing.NewReferenceFromStrings("refs/tags/0.4.3", "commit7"),
+		plumbing.NewReferenceFromStrings("refs/tags/1.0.0", "commit8"),
+		plumbing.NewReferenceFromStrings("refs/tags/1.1.0", "commit9"),
+		plumbing.NewReferenceFromStrings("refs/tags/1.1.1", "commit10"),
 	}
 
 	// Create mock reference iterator
@@ -83,7 +83,7 @@ func TestLatestTag(t *testing.T) {
 
 	// Assert the expected result
 	assert.NoError(t, err)
-	assert.Equal(t, "refs/tags/v1.1.1", tag)
+	assert.Equal(t, "refs/tags/1.1.1", tag)
 }
 
 func TestGetLastActivity(t *testing.T) {


### PR DESCRIPTION
- removes the idea of using a prefix to avoid possible errors in the future and just takes all the numbers