### PR TITLE
chore: remove dot-slash from pathStatic

### DIFF
--- a/pkg/cmd/deploy/deploy.go
+++ b/pkg/cmd/deploy/deploy.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/MakeNowJust/heredoc"
 	msg "github.com/aziontech/azion-cli/messages/deploy"
@@ -106,13 +107,14 @@ func (cmd *DeployCmd) Run(f *cmdutil.Factory) error {
 		pathStatic = ".vercel/output/static"
 		conf.Function.File = "./out/worker.js"
 	case "static":
-		pathStatic = "./dist"
+		pathStatic = "dist"
 	default:
 		pathStatic = ".edge/storage"
 	}
 
 	if Path != "" {
-		pathStatic = Path
+		modified := strings.Replace(Path, "./", "", -1)
+		pathStatic = modified
 	}
 
 	client := api.NewClient(f.HttpClient, f.Config.GetString("api_url"), f.Config.GetString("token"))


### PR DESCRIPTION
**WHAT**
- Remove dot-slash "./" from pathStatic. filepath.Walk function removes this when analyzing files, so when we call upload function we cannot trim the name because it will not contain the "./"
