### PR TITLE
fix: reset httpResp buffer to be read again

### DIFF
--- a/pkg/api/domains/domains.go
+++ b/pkg/api/domains/domains.go
@@ -74,8 +74,6 @@ func (c *Client) Create(ctx context.Context, req *CreateRequest) (DomainResponse
 	if err != nil {
 		if httpResp != nil {
 			logger.Debug("Error while creating a domain", zap.Error(err))
-			logger.Debug("", zap.Any("Status Code", httpResp.StatusCode))
-			logger.Debug("", zap.Any("Headers", httpResp.Header))
 			err := utils.LogAndRewindBody(httpResp)
 			if err != nil {
 				return nil, err
@@ -96,8 +94,6 @@ func (c *Client) Update(ctx context.Context, req *UpdateRequest) (DomainResponse
 	if err != nil {
 		if httpResp != nil {
 			logger.Debug("Error while updating a domain", zap.Error(err))
-			logger.Debug("", zap.Any("Status Code", httpResp.StatusCode))
-			logger.Debug("", zap.Any("Headers", httpResp.Header))
 			err := utils.LogAndRewindBody(httpResp)
 			if err != nil {
 				return nil, err

--- a/pkg/api/domains/domains.go
+++ b/pkg/api/domains/domains.go
@@ -1,9 +1,7 @@
 package domains
 
 import (
-	"bytes"
 	"context"
-	"io"
 	"net/http"
 	"strconv"
 	"time"
@@ -78,16 +76,10 @@ func (c *Client) Create(ctx context.Context, req *CreateRequest) (DomainResponse
 			logger.Debug("Error while creating a domain", zap.Error(err))
 			logger.Debug("", zap.Any("Status Code", httpResp.StatusCode))
 			logger.Debug("", zap.Any("Headers", httpResp.Header))
-			bodyBytes, err := io.ReadAll(httpResp.Body)
+			err := utils.LogAndRewindBody(httpResp)
 			if err != nil {
-				logger.Debug("Error while reading body of the http response", zap.Error(err))
-				return nil, utils.ErrorPerStatusCode(httpResp, err)
+				return nil, err
 			}
-			// Convert the body bytes to string
-			bodyString := string(bodyBytes)
-			logger.Debug("", zap.Any("Body", bodyString))
-			// Rewind the response body to the beginning
-			httpResp.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 		}
 		return nil, utils.ErrorPerStatusCode(httpResp, err)
 	}
@@ -106,16 +98,10 @@ func (c *Client) Update(ctx context.Context, req *UpdateRequest) (DomainResponse
 			logger.Debug("Error while updating a domain", zap.Error(err))
 			logger.Debug("", zap.Any("Status Code", httpResp.StatusCode))
 			logger.Debug("", zap.Any("Headers", httpResp.Header))
-			bodyBytes, err := io.ReadAll(httpResp.Body)
+			err := utils.LogAndRewindBody(httpResp)
 			if err != nil {
-				logger.Debug("Error while reading body of the http response", zap.Error(err))
-				return nil, utils.ErrorPerStatusCode(httpResp, err)
+				return nil, err
 			}
-			// Convert the body bytes to string
-			bodyString := string(bodyBytes)
-			logger.Debug("", zap.Any("Body", bodyString))
-			// Rewind the response body to the beginning
-			httpResp.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 		}
 		return nil, utils.ErrorPerStatusCode(httpResp, err)
 	}

--- a/pkg/api/domains/domains.go
+++ b/pkg/api/domains/domains.go
@@ -1,6 +1,7 @@
 package domains
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"net/http"
@@ -77,12 +78,16 @@ func (c *Client) Create(ctx context.Context, req *CreateRequest) (DomainResponse
 			logger.Debug("Error while creating a domain", zap.Error(err))
 			logger.Debug("", zap.Any("Status Code", httpResp.StatusCode))
 			logger.Debug("", zap.Any("Headers", httpResp.Header))
-			body, err := io.ReadAll(httpResp.Body)
+			bodyBytes, err := io.ReadAll(httpResp.Body)
 			if err != nil {
 				logger.Debug("Error while reading body of the http response", zap.Error(err))
 				return nil, utils.ErrorPerStatusCode(httpResp, err)
 			}
-			logger.Debug("", zap.Any("Body", string(body)))
+			// Convert the body bytes to string
+			bodyString := string(bodyBytes)
+			logger.Debug("", zap.Any("Body", bodyString))
+			// Rewind the response body to the beginning
+			httpResp.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 		}
 		return nil, utils.ErrorPerStatusCode(httpResp, err)
 	}
@@ -101,12 +106,16 @@ func (c *Client) Update(ctx context.Context, req *UpdateRequest) (DomainResponse
 			logger.Debug("Error while updating a domain", zap.Error(err))
 			logger.Debug("", zap.Any("Status Code", httpResp.StatusCode))
 			logger.Debug("", zap.Any("Headers", httpResp.Header))
-			body, err := io.ReadAll(httpResp.Body)
+			bodyBytes, err := io.ReadAll(httpResp.Body)
 			if err != nil {
 				logger.Debug("Error while reading body of the http response", zap.Error(err))
 				return nil, utils.ErrorPerStatusCode(httpResp, err)
 			}
-			logger.Debug("", zap.Any("Body", string(body)))
+			// Convert the body bytes to string
+			bodyString := string(bodyBytes)
+			logger.Debug("", zap.Any("Body", bodyString))
+			// Rewind the response body to the beginning
+			httpResp.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 		}
 		return nil, utils.ErrorPerStatusCode(httpResp, err)
 	}

--- a/pkg/api/edge_applications/create.go
+++ b/pkg/api/edge_applications/create.go
@@ -1,6 +1,7 @@
 package edge_applications
 
 import (
+	"bytes"
 	"context"
 	"io"
 
@@ -52,12 +53,16 @@ func (c *Client) Create(ctx context.Context, req *CreateRequest,
 			logger.Debug("Error while creating an edge application", zap.Error(err))
 			logger.Debug("", zap.Any("Status Code", httpResp.StatusCode))
 			logger.Debug("", zap.Any("Headers", httpResp.Header))
-			body, err := io.ReadAll(httpResp.Body)
+			bodyBytes, err := io.ReadAll(httpResp.Body)
 			if err != nil {
 				logger.Debug("Error while reading body of the http response", zap.Error(err))
 				return nil, utils.ErrorPerStatusCode(httpResp, err)
 			}
-			logger.Debug("", zap.Any("Body", string(body)))
+			// Convert the body bytes to string
+			bodyString := string(bodyBytes)
+			logger.Debug("", zap.Any("Body", bodyString))
+			// Rewind the response body to the beginning
+			httpResp.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 		}
 		return nil, utils.ErrorPerStatusCode(httpResp, err)
 	}

--- a/pkg/api/edge_applications/create.go
+++ b/pkg/api/edge_applications/create.go
@@ -1,9 +1,7 @@
 package edge_applications
 
 import (
-	"bytes"
 	"context"
-	"io"
 
 	sdk "github.com/aziontech/azionapi-go-sdk/edgeapplications"
 	"go.uber.org/zap"
@@ -53,16 +51,10 @@ func (c *Client) Create(ctx context.Context, req *CreateRequest,
 			logger.Debug("Error while creating an edge application", zap.Error(err))
 			logger.Debug("", zap.Any("Status Code", httpResp.StatusCode))
 			logger.Debug("", zap.Any("Headers", httpResp.Header))
-			bodyBytes, err := io.ReadAll(httpResp.Body)
+			err := utils.LogAndRewindBody(httpResp)
 			if err != nil {
-				logger.Debug("Error while reading body of the http response", zap.Error(err))
-				return nil, utils.ErrorPerStatusCode(httpResp, err)
+				return nil, err
 			}
-			// Convert the body bytes to string
-			bodyString := string(bodyBytes)
-			logger.Debug("", zap.Any("Body", bodyString))
-			// Rewind the response body to the beginning
-			httpResp.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 		}
 		return nil, utils.ErrorPerStatusCode(httpResp, err)
 	}

--- a/pkg/api/edge_applications/create.go
+++ b/pkg/api/edge_applications/create.go
@@ -49,8 +49,6 @@ func (c *Client) Create(ctx context.Context, req *CreateRequest,
 	if err != nil {
 		if httpResp != nil {
 			logger.Debug("Error while creating an edge application", zap.Error(err))
-			logger.Debug("", zap.Any("Status Code", httpResp.StatusCode))
-			logger.Debug("", zap.Any("Headers", httpResp.Header))
 			err := utils.LogAndRewindBody(httpResp)
 			if err != nil {
 				return nil, err

--- a/pkg/api/edge_applications/edge_applications.go
+++ b/pkg/api/edge_applications/edge_applications.go
@@ -1,11 +1,9 @@
 package edge_applications
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -164,16 +162,10 @@ func (c *Client) Update(ctx context.Context, req *UpdateRequest) (EdgeApplicatio
 			logger.Debug("Error while updating an edge application", zap.Error(err))
 			logger.Debug("", zap.Any("Status Code", httpResp.StatusCode))
 			logger.Debug("", zap.Any("Headers", httpResp.Header))
-			bodyBytes, err := io.ReadAll(httpResp.Body)
+			err := utils.LogAndRewindBody(httpResp)
 			if err != nil {
-				logger.Debug("Error while reading body of the http response", zap.Error(err))
-				return nil, utils.ErrorPerStatusCode(httpResp, err)
+				return nil, err
 			}
-			// Convert the body bytes to string
-			bodyString := string(bodyBytes)
-			logger.Debug("", zap.Any("Body", bodyString))
-			// Rewind the response body to the beginning
-			httpResp.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 		}
 		return nil, utils.ErrorPerStatusCode(httpResp, err)
 	}
@@ -210,16 +202,10 @@ func (c *Client) CreateInstancePublish(ctx context.Context, req *CreateInstanceR
 			logger.Debug("Error while creating an edge function instance", zap.Error(err))
 			logger.Debug("", zap.Any("Status Code", httpResp.StatusCode))
 			logger.Debug("", zap.Any("Headers", httpResp.Header))
-			bodyBytes, err := io.ReadAll(httpResp.Body)
+			err := utils.LogAndRewindBody(httpResp)
 			if err != nil {
-				logger.Debug("Error while reading body of the http response", zap.Error(err))
-				return nil, utils.ErrorPerStatusCode(httpResp, err)
+				return nil, err
 			}
-			// Convert the body bytes to string
-			bodyString := string(bodyBytes)
-			logger.Debug("", zap.Any("Body", bodyString))
-			// Rewind the response body to the beginning
-			httpResp.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 		}
 		return nil, utils.ErrorPerStatusCode(httpResp, err)
 	}
@@ -238,16 +224,10 @@ func (c *Client) Delete(ctx context.Context, id int64) error {
 			logger.Debug("Error while deleting an edge application", zap.Error(err))
 			logger.Debug("", zap.Any("Status Code", httpResp.StatusCode))
 			logger.Debug("", zap.Any("Headers", httpResp.Header))
-			bodyBytes, err := io.ReadAll(httpResp.Body)
+			err := utils.LogAndRewindBody(httpResp)
 			if err != nil {
-				logger.Debug("Error while reading body of the http response", zap.Error(err))
-				return utils.ErrorPerStatusCode(httpResp, err)
+				return err
 			}
-			// Convert the body bytes to string
-			bodyString := string(bodyBytes)
-			logger.Debug("", zap.Any("Body", bodyString))
-			// Rewind the response body to the beginning
-			httpResp.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 		}
 
 		return utils.ErrorPerStatusCode(httpResp, err)
@@ -297,16 +277,10 @@ func (c *Client) CreateOrigins(ctx context.Context, edgeApplicationID int64, req
 			logger.Debug("Error while creating an origin", zap.Error(err))
 			logger.Debug("", zap.Any("Status Code", httpResp.StatusCode))
 			logger.Debug("", zap.Any("Headers", httpResp.Header))
-			bodyBytes, err := io.ReadAll(httpResp.Body)
+			err := utils.LogAndRewindBody(httpResp)
 			if err != nil {
-				logger.Debug("Error while reading body of the http response", zap.Error(err))
-				return nil, utils.ErrorPerStatusCode(httpResp, err)
+				return nil, err
 			}
-			// Convert the body bytes to string
-			bodyString := string(bodyBytes)
-			logger.Debug("", zap.Any("Body", bodyString))
-			// Rewind the response body to the beginning
-			httpResp.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 		}
 		return nil, utils.ErrorPerStatusCode(httpResp, err)
 	}
@@ -439,16 +413,10 @@ func (c *Client) ListRulesEngine(ctx context.Context, opts *contracts.ListOption
 			logger.Debug("Error while listing rules engine", zap.Error(err))
 			logger.Debug("", zap.Any("Status Code", httpResp.StatusCode))
 			logger.Debug("", zap.Any("Headers", httpResp.Header))
-			bodyBytes, err := io.ReadAll(httpResp.Body)
+			err := utils.LogAndRewindBody(httpResp)
 			if err != nil {
-				logger.Debug("Error while reading body of the http response", zap.Error(err))
-				return nil, utils.ErrorPerStatusCode(httpResp, err)
+				return nil, err
 			}
-			// Convert the body bytes to string
-			bodyString := string(bodyBytes)
-			logger.Debug("", zap.Any("Body", bodyString))
-			// Rewind the response body to the beginning
-			httpResp.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 		}
 		return nil, utils.ErrorPerStatusCode(httpResp, err)
 	}
@@ -464,16 +432,10 @@ func (c *Client) GetRulesEngine(ctx context.Context, edgeApplicationID, rulesID 
 			logger.Debug("Error while describing a rules engine", zap.Error(err))
 			logger.Debug("", zap.Any("Status Code", httpResp.StatusCode))
 			logger.Debug("", zap.Any("Headers", httpResp.Header))
-			bodyBytes, err := io.ReadAll(httpResp.Body)
+			err := utils.LogAndRewindBody(httpResp)
 			if err != nil {
-				logger.Debug("Error while reading body of the http response", zap.Error(err))
-				return nil, utils.ErrorPerStatusCode(httpResp, err)
+				return nil, err
 			}
-			// Convert the body bytes to string
-			bodyString := string(bodyBytes)
-			logger.Debug("", zap.Any("Body", bodyString))
-			// Rewind the response body to the beginning
-			httpResp.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 		}
 		return nil, utils.ErrorPerStatusCode(httpResp, err)
 	}
@@ -488,16 +450,10 @@ func (c *Client) DeleteRulesEngine(ctx context.Context, edgeApplicationID int64,
 			logger.Debug("Error while deleting a rules engine", zap.Error(err))
 			logger.Debug("", zap.Any("Status Code", httpResp.StatusCode))
 			logger.Debug("", zap.Any("Headers", httpResp.Header))
-			bodyBytes, err := io.ReadAll(httpResp.Body)
+			err := utils.LogAndRewindBody(httpResp)
 			if err != nil {
-				logger.Debug("Error while reading body of the http response", zap.Error(err))
-				return utils.ErrorPerStatusCode(httpResp, err)
+				return err
 			}
-			// Convert the body bytes to string
-			bodyString := string(bodyBytes)
-			logger.Debug("", zap.Any("Body", bodyString))
-			// Rewind the response body to the beginning
-			httpResp.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 		}
 		return utils.ErrorPerStatusCode(httpResp, err)
 	}
@@ -539,16 +495,10 @@ func (c *Client) UpdateRulesEnginePublish(ctx context.Context, req *UpdateRulesE
 			logger.Debug("Error while updating a rules engine", zap.Error(err))
 			logger.Debug("", zap.Any("Status Code", httpResp.StatusCode))
 			logger.Debug("", zap.Any("Headers", httpResp.Header))
-			bodyBytes, err := io.ReadAll(httpResp.Body)
+			err := utils.LogAndRewindBody(httpResp)
 			if err != nil {
-				logger.Debug("Error while reading body of the http response", zap.Error(err))
-				return nil, utils.ErrorPerStatusCode(httpResp, err)
+				return nil, err
 			}
-			// Convert the body bytes to string
-			bodyString := string(bodyBytes)
-			logger.Debug("", zap.Any("Body", bodyString))
-			// Rewind the response body to the beginning
-			httpResp.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 		}
 		return nil, utils.ErrorPerStatusCode(httpResp, err)
 	}
@@ -566,16 +516,10 @@ func (c *Client) UpdateRulesEngine(ctx context.Context, req *UpdateRulesEngineRe
 			logger.Debug("Error while updating a rules engine", zap.Error(err))
 			logger.Debug("", zap.Any("Status Code", httpResp.StatusCode))
 			logger.Debug("", zap.Any("Headers", httpResp.Header))
-			bodyBytes, err := io.ReadAll(httpResp.Body)
+			err := utils.LogAndRewindBody(httpResp)
 			if err != nil {
-				logger.Debug("Error while reading body of the http response", zap.Error(err))
-				return nil, utils.ErrorPerStatusCode(httpResp, err)
+				return nil, err
 			}
-			// Convert the body bytes to string
-			bodyString := string(bodyBytes)
-			logger.Debug("", zap.Any("Body", bodyString))
-			// Rewind the response body to the beginning
-			httpResp.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 		}
 	}
 
@@ -593,16 +537,10 @@ func (c *Client) CreateRulesEngine(ctx context.Context, edgeApplicationID int64,
 			logger.Debug("Error while updating a rules engine", zap.Error(err))
 			logger.Debug("", zap.Any("Status Code", httpResp.StatusCode))
 			logger.Debug("", zap.Any("Headers", httpResp.Header))
-			bodyBytes, err := io.ReadAll(httpResp.Body)
+			err := utils.LogAndRewindBody(httpResp)
 			if err != nil {
-				logger.Debug("Error while reading body of the http response", zap.Error(err))
-				return nil, utils.ErrorPerStatusCode(httpResp, err)
+				return nil, err
 			}
-			// Convert the body bytes to string
-			bodyString := string(bodyBytes)
-			logger.Debug("", zap.Any("Body", bodyString))
-			// Rewind the response body to the beginning
-			httpResp.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 		}
 	}
 	return &resp.Results, nil
@@ -771,16 +709,10 @@ func (c *Client) CreateCacheSettingsNextApplication(ctx context.Context, req *Cr
 			logger.Debug("Error while creating a cache setting", zap.Error(err))
 			logger.Debug("", zap.Any("Status Code", httpResp.StatusCode))
 			logger.Debug("", zap.Any("Headers", httpResp.Header))
-			bodyBytes, err := io.ReadAll(httpResp.Body)
+			err := utils.LogAndRewindBody(httpResp)
 			if err != nil {
-				logger.Debug("Error while reading body of the http response", zap.Error(err))
-				return nil, utils.ErrorPerStatusCode(httpResp, err)
+				return nil, err
 			}
-			// Convert the body bytes to string
-			bodyString := string(bodyBytes)
-			logger.Debug("", zap.Any("Body", bodyString))
-			// Rewind the response body to the beginning
-			httpResp.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 		}
 		return nil, utils.ErrorPerStatusCode(httpResp, err)
 	}
@@ -829,16 +761,10 @@ func (c *Client) CreateRulesEngineNextApplication(ctx context.Context, applicati
 			logger.Debug("Error while creating a rules engine", zap.Error(err))
 			logger.Debug("", zap.Any("Status Code", httpResp.StatusCode))
 			logger.Debug("", zap.Any("Headers", httpResp.Header))
-			bodyBytes, err := io.ReadAll(httpResp.Body)
+			err := utils.LogAndRewindBody(httpResp)
 			if err != nil {
-				logger.Debug("Error while reading body of the http response", zap.Error(err))
-				return utils.ErrorPerStatusCode(httpResp, err)
+				return err
 			}
-			// Convert the body bytes to string
-			bodyString := string(bodyBytes)
-			logger.Debug("", zap.Any("Body", bodyString))
-			// Rewind the response body to the beginning
-			httpResp.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 		}
 		logger.Debug("", zap.Any("Error", err.Error()))
 		return utils.ErrorPerStatusCode(httpResp, err)
@@ -872,16 +798,10 @@ func (c *Client) CreateRulesEngineNextApplication(ctx context.Context, applicati
 			logger.Debug("Error while creating a rules engine", zap.Error(err))
 			logger.Debug("", zap.Any("Status Code", httpResp.StatusCode))
 			logger.Debug("", zap.Any("Headers", httpResp.Header))
-			bodyBytes, err := io.ReadAll(httpResp.Body)
+			err := utils.LogAndRewindBody(httpResp)
 			if err != nil {
-				logger.Debug("Error while reading body of the http response", zap.Error(err))
-				return utils.ErrorPerStatusCode(httpResp, err)
+				return err
 			}
-			// Convert the body bytes to string
-			bodyString := string(bodyBytes)
-			logger.Debug("", zap.Any("Body", bodyString))
-			// Rewind the response body to the beginning
-			httpResp.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 		}
 	}
 

--- a/pkg/api/edge_applications/edge_applications.go
+++ b/pkg/api/edge_applications/edge_applications.go
@@ -160,8 +160,6 @@ func (c *Client) Update(ctx context.Context, req *UpdateRequest) (EdgeApplicatio
 	if err != nil {
 		if httpResp != nil {
 			logger.Debug("Error while updating an edge application", zap.Error(err))
-			logger.Debug("", zap.Any("Status Code", httpResp.StatusCode))
-			logger.Debug("", zap.Any("Headers", httpResp.Header))
 			err := utils.LogAndRewindBody(httpResp)
 			if err != nil {
 				return nil, err
@@ -200,8 +198,6 @@ func (c *Client) CreateInstancePublish(ctx context.Context, req *CreateInstanceR
 	if err != nil {
 		if httpResp != nil {
 			logger.Debug("Error while creating an edge function instance", zap.Error(err))
-			logger.Debug("", zap.Any("Status Code", httpResp.StatusCode))
-			logger.Debug("", zap.Any("Headers", httpResp.Header))
 			err := utils.LogAndRewindBody(httpResp)
 			if err != nil {
 				return nil, err
@@ -222,8 +218,6 @@ func (c *Client) Delete(ctx context.Context, id int64) error {
 	if err != nil {
 		if httpResp != nil {
 			logger.Debug("Error while deleting an edge application", zap.Error(err))
-			logger.Debug("", zap.Any("Status Code", httpResp.StatusCode))
-			logger.Debug("", zap.Any("Headers", httpResp.Header))
 			err := utils.LogAndRewindBody(httpResp)
 			if err != nil {
 				return err
@@ -275,8 +269,6 @@ func (c *Client) CreateOrigins(ctx context.Context, edgeApplicationID int64, req
 	if err != nil {
 		if httpResp != nil {
 			logger.Debug("Error while creating an origin", zap.Error(err))
-			logger.Debug("", zap.Any("Status Code", httpResp.StatusCode))
-			logger.Debug("", zap.Any("Headers", httpResp.Header))
 			err := utils.LogAndRewindBody(httpResp)
 			if err != nil {
 				return nil, err
@@ -411,8 +403,6 @@ func (c *Client) ListRulesEngine(ctx context.Context, opts *contracts.ListOption
 	if err != nil {
 		if httpResp != nil {
 			logger.Debug("Error while listing rules engine", zap.Error(err))
-			logger.Debug("", zap.Any("Status Code", httpResp.StatusCode))
-			logger.Debug("", zap.Any("Headers", httpResp.Header))
 			err := utils.LogAndRewindBody(httpResp)
 			if err != nil {
 				return nil, err
@@ -430,8 +420,6 @@ func (c *Client) GetRulesEngine(ctx context.Context, edgeApplicationID, rulesID 
 	if err != nil {
 		if httpResp != nil {
 			logger.Debug("Error while describing a rules engine", zap.Error(err))
-			logger.Debug("", zap.Any("Status Code", httpResp.StatusCode))
-			logger.Debug("", zap.Any("Headers", httpResp.Header))
 			err := utils.LogAndRewindBody(httpResp)
 			if err != nil {
 				return nil, err
@@ -448,8 +436,6 @@ func (c *Client) DeleteRulesEngine(ctx context.Context, edgeApplicationID int64,
 	if err != nil {
 		if httpResp != nil {
 			logger.Debug("Error while deleting a rules engine", zap.Error(err))
-			logger.Debug("", zap.Any("Status Code", httpResp.StatusCode))
-			logger.Debug("", zap.Any("Headers", httpResp.Header))
 			err := utils.LogAndRewindBody(httpResp)
 			if err != nil {
 				return err
@@ -493,8 +479,6 @@ func (c *Client) UpdateRulesEnginePublish(ctx context.Context, req *UpdateRulesE
 	if err != nil {
 		if httpResp != nil {
 			logger.Debug("Error while updating a rules engine", zap.Error(err))
-			logger.Debug("", zap.Any("Status Code", httpResp.StatusCode))
-			logger.Debug("", zap.Any("Headers", httpResp.Header))
 			err := utils.LogAndRewindBody(httpResp)
 			if err != nil {
 				return nil, err
@@ -514,8 +498,6 @@ func (c *Client) UpdateRulesEngine(ctx context.Context, req *UpdateRulesEngineRe
 	if err != nil {
 		if httpResp != nil {
 			logger.Debug("Error while updating a rules engine", zap.Error(err))
-			logger.Debug("", zap.Any("Status Code", httpResp.StatusCode))
-			logger.Debug("", zap.Any("Headers", httpResp.Header))
 			err := utils.LogAndRewindBody(httpResp)
 			if err != nil {
 				return nil, err
@@ -535,8 +517,6 @@ func (c *Client) CreateRulesEngine(ctx context.Context, edgeApplicationID int64,
 	if err != nil {
 		if httpResp != nil {
 			logger.Debug("Error while updating a rules engine", zap.Error(err))
-			logger.Debug("", zap.Any("Status Code", httpResp.StatusCode))
-			logger.Debug("", zap.Any("Headers", httpResp.Header))
 			err := utils.LogAndRewindBody(httpResp)
 			if err != nil {
 				return nil, err
@@ -707,8 +687,6 @@ func (c *Client) CreateCacheSettingsNextApplication(ctx context.Context, req *Cr
 	if err != nil {
 		if httpResp != nil {
 			logger.Debug("Error while creating a cache setting", zap.Error(err))
-			logger.Debug("", zap.Any("Status Code", httpResp.StatusCode))
-			logger.Debug("", zap.Any("Headers", httpResp.Header))
 			err := utils.LogAndRewindBody(httpResp)
 			if err != nil {
 				return nil, err
@@ -759,8 +737,6 @@ func (c *Client) CreateRulesEngineNextApplication(ctx context.Context, applicati
 	if err != nil {
 		if httpResp != nil {
 			logger.Debug("Error while creating a rules engine", zap.Error(err))
-			logger.Debug("", zap.Any("Status Code", httpResp.StatusCode))
-			logger.Debug("", zap.Any("Headers", httpResp.Header))
 			err := utils.LogAndRewindBody(httpResp)
 			if err != nil {
 				return err
@@ -796,8 +772,6 @@ func (c *Client) CreateRulesEngineNextApplication(ctx context.Context, applicati
 	if err != nil {
 		if httpResp != nil {
 			logger.Debug("Error while creating a rules engine", zap.Error(err))
-			logger.Debug("", zap.Any("Status Code", httpResp.StatusCode))
-			logger.Debug("", zap.Any("Headers", httpResp.Header))
 			err := utils.LogAndRewindBody(httpResp)
 			if err != nil {
 				return err

--- a/pkg/api/edge_applications/edge_applications.go
+++ b/pkg/api/edge_applications/edge_applications.go
@@ -1,6 +1,7 @@
 package edge_applications
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -163,12 +164,16 @@ func (c *Client) Update(ctx context.Context, req *UpdateRequest) (EdgeApplicatio
 			logger.Debug("Error while updating an edge application", zap.Error(err))
 			logger.Debug("", zap.Any("Status Code", httpResp.StatusCode))
 			logger.Debug("", zap.Any("Headers", httpResp.Header))
-			body, err := io.ReadAll(httpResp.Body)
+			bodyBytes, err := io.ReadAll(httpResp.Body)
 			if err != nil {
 				logger.Debug("Error while reading body of the http response", zap.Error(err))
 				return nil, utils.ErrorPerStatusCode(httpResp, err)
 			}
-			logger.Debug("", zap.Any("Body", string(body)))
+			// Convert the body bytes to string
+			bodyString := string(bodyBytes)
+			logger.Debug("", zap.Any("Body", bodyString))
+			// Rewind the response body to the beginning
+			httpResp.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 		}
 		return nil, utils.ErrorPerStatusCode(httpResp, err)
 	}
@@ -205,12 +210,16 @@ func (c *Client) CreateInstancePublish(ctx context.Context, req *CreateInstanceR
 			logger.Debug("Error while creating an edge function instance", zap.Error(err))
 			logger.Debug("", zap.Any("Status Code", httpResp.StatusCode))
 			logger.Debug("", zap.Any("Headers", httpResp.Header))
-			body, err := io.ReadAll(httpResp.Body)
+			bodyBytes, err := io.ReadAll(httpResp.Body)
 			if err != nil {
 				logger.Debug("Error while reading body of the http response", zap.Error(err))
 				return nil, utils.ErrorPerStatusCode(httpResp, err)
 			}
-			logger.Debug("", zap.Any("Body", string(body)))
+			// Convert the body bytes to string
+			bodyString := string(bodyBytes)
+			logger.Debug("", zap.Any("Body", bodyString))
+			// Rewind the response body to the beginning
+			httpResp.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 		}
 		return nil, utils.ErrorPerStatusCode(httpResp, err)
 	}
@@ -229,12 +238,16 @@ func (c *Client) Delete(ctx context.Context, id int64) error {
 			logger.Debug("Error while deleting an edge application", zap.Error(err))
 			logger.Debug("", zap.Any("Status Code", httpResp.StatusCode))
 			logger.Debug("", zap.Any("Headers", httpResp.Header))
-			body, err := io.ReadAll(httpResp.Body)
+			bodyBytes, err := io.ReadAll(httpResp.Body)
 			if err != nil {
 				logger.Debug("Error while reading body of the http response", zap.Error(err))
 				return utils.ErrorPerStatusCode(httpResp, err)
 			}
-			logger.Debug("", zap.Any("Body", string(body)))
+			// Convert the body bytes to string
+			bodyString := string(bodyBytes)
+			logger.Debug("", zap.Any("Body", bodyString))
+			// Rewind the response body to the beginning
+			httpResp.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 		}
 
 		return utils.ErrorPerStatusCode(httpResp, err)
@@ -284,12 +297,16 @@ func (c *Client) CreateOrigins(ctx context.Context, edgeApplicationID int64, req
 			logger.Debug("Error while creating an origin", zap.Error(err))
 			logger.Debug("", zap.Any("Status Code", httpResp.StatusCode))
 			logger.Debug("", zap.Any("Headers", httpResp.Header))
-			body, err := io.ReadAll(httpResp.Body)
+			bodyBytes, err := io.ReadAll(httpResp.Body)
 			if err != nil {
 				logger.Debug("Error while reading body of the http response", zap.Error(err))
 				return nil, utils.ErrorPerStatusCode(httpResp, err)
 			}
-			logger.Debug("", zap.Any("Body", string(body)))
+			// Convert the body bytes to string
+			bodyString := string(bodyBytes)
+			logger.Debug("", zap.Any("Body", bodyString))
+			// Rewind the response body to the beginning
+			httpResp.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 		}
 		return nil, utils.ErrorPerStatusCode(httpResp, err)
 	}
@@ -422,12 +439,16 @@ func (c *Client) ListRulesEngine(ctx context.Context, opts *contracts.ListOption
 			logger.Debug("Error while listing rules engine", zap.Error(err))
 			logger.Debug("", zap.Any("Status Code", httpResp.StatusCode))
 			logger.Debug("", zap.Any("Headers", httpResp.Header))
-			body, err := io.ReadAll(httpResp.Body)
+			bodyBytes, err := io.ReadAll(httpResp.Body)
 			if err != nil {
 				logger.Debug("Error while reading body of the http response", zap.Error(err))
 				return nil, utils.ErrorPerStatusCode(httpResp, err)
 			}
-			logger.Debug("", zap.Any("Body", string(body)))
+			// Convert the body bytes to string
+			bodyString := string(bodyBytes)
+			logger.Debug("", zap.Any("Body", bodyString))
+			// Rewind the response body to the beginning
+			httpResp.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 		}
 		return nil, utils.ErrorPerStatusCode(httpResp, err)
 	}
@@ -443,12 +464,16 @@ func (c *Client) GetRulesEngine(ctx context.Context, edgeApplicationID, rulesID 
 			logger.Debug("Error while describing a rules engine", zap.Error(err))
 			logger.Debug("", zap.Any("Status Code", httpResp.StatusCode))
 			logger.Debug("", zap.Any("Headers", httpResp.Header))
-			body, err := io.ReadAll(httpResp.Body)
+			bodyBytes, err := io.ReadAll(httpResp.Body)
 			if err != nil {
 				logger.Debug("Error while reading body of the http response", zap.Error(err))
 				return nil, utils.ErrorPerStatusCode(httpResp, err)
 			}
-			logger.Debug("", zap.Any("Body", string(body)))
+			// Convert the body bytes to string
+			bodyString := string(bodyBytes)
+			logger.Debug("", zap.Any("Body", bodyString))
+			// Rewind the response body to the beginning
+			httpResp.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 		}
 		return nil, utils.ErrorPerStatusCode(httpResp, err)
 	}
@@ -463,12 +488,16 @@ func (c *Client) DeleteRulesEngine(ctx context.Context, edgeApplicationID int64,
 			logger.Debug("Error while deleting a rules engine", zap.Error(err))
 			logger.Debug("", zap.Any("Status Code", httpResp.StatusCode))
 			logger.Debug("", zap.Any("Headers", httpResp.Header))
-			body, err := io.ReadAll(httpResp.Body)
+			bodyBytes, err := io.ReadAll(httpResp.Body)
 			if err != nil {
 				logger.Debug("Error while reading body of the http response", zap.Error(err))
 				return utils.ErrorPerStatusCode(httpResp, err)
 			}
-			logger.Debug("", zap.Any("Body", string(body)))
+			// Convert the body bytes to string
+			bodyString := string(bodyBytes)
+			logger.Debug("", zap.Any("Body", bodyString))
+			// Rewind the response body to the beginning
+			httpResp.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 		}
 		return utils.ErrorPerStatusCode(httpResp, err)
 	}
@@ -510,12 +539,16 @@ func (c *Client) UpdateRulesEnginePublish(ctx context.Context, req *UpdateRulesE
 			logger.Debug("Error while updating a rules engine", zap.Error(err))
 			logger.Debug("", zap.Any("Status Code", httpResp.StatusCode))
 			logger.Debug("", zap.Any("Headers", httpResp.Header))
-			body, err := io.ReadAll(httpResp.Body)
+			bodyBytes, err := io.ReadAll(httpResp.Body)
 			if err != nil {
 				logger.Debug("Error while reading body of the http response", zap.Error(err))
 				return nil, utils.ErrorPerStatusCode(httpResp, err)
 			}
-			logger.Debug("", zap.Any("Body", string(body)))
+			// Convert the body bytes to string
+			bodyString := string(bodyBytes)
+			logger.Debug("", zap.Any("Body", bodyString))
+			// Rewind the response body to the beginning
+			httpResp.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 		}
 		return nil, utils.ErrorPerStatusCode(httpResp, err)
 	}
@@ -533,12 +566,16 @@ func (c *Client) UpdateRulesEngine(ctx context.Context, req *UpdateRulesEngineRe
 			logger.Debug("Error while updating a rules engine", zap.Error(err))
 			logger.Debug("", zap.Any("Status Code", httpResp.StatusCode))
 			logger.Debug("", zap.Any("Headers", httpResp.Header))
-			body, err := io.ReadAll(httpResp.Body)
+			bodyBytes, err := io.ReadAll(httpResp.Body)
 			if err != nil {
 				logger.Debug("Error while reading body of the http response", zap.Error(err))
 				return nil, utils.ErrorPerStatusCode(httpResp, err)
 			}
-			logger.Debug("", zap.Any("Body", string(body)))
+			// Convert the body bytes to string
+			bodyString := string(bodyBytes)
+			logger.Debug("", zap.Any("Body", bodyString))
+			// Rewind the response body to the beginning
+			httpResp.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 		}
 	}
 
@@ -556,12 +593,16 @@ func (c *Client) CreateRulesEngine(ctx context.Context, edgeApplicationID int64,
 			logger.Debug("Error while updating a rules engine", zap.Error(err))
 			logger.Debug("", zap.Any("Status Code", httpResp.StatusCode))
 			logger.Debug("", zap.Any("Headers", httpResp.Header))
-			body, err := io.ReadAll(httpResp.Body)
+			bodyBytes, err := io.ReadAll(httpResp.Body)
 			if err != nil {
 				logger.Debug("Error while reading body of the http response", zap.Error(err))
 				return nil, utils.ErrorPerStatusCode(httpResp, err)
 			}
-			logger.Debug("", zap.Any("Body", string(body)))
+			// Convert the body bytes to string
+			bodyString := string(bodyBytes)
+			logger.Debug("", zap.Any("Body", bodyString))
+			// Rewind the response body to the beginning
+			httpResp.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 		}
 	}
 	return &resp.Results, nil
@@ -730,12 +771,16 @@ func (c *Client) CreateCacheSettingsNextApplication(ctx context.Context, req *Cr
 			logger.Debug("Error while creating a cache setting", zap.Error(err))
 			logger.Debug("", zap.Any("Status Code", httpResp.StatusCode))
 			logger.Debug("", zap.Any("Headers", httpResp.Header))
-			body, err := io.ReadAll(httpResp.Body)
+			bodyBytes, err := io.ReadAll(httpResp.Body)
 			if err != nil {
 				logger.Debug("Error while reading body of the http response", zap.Error(err))
 				return nil, utils.ErrorPerStatusCode(httpResp, err)
 			}
-			logger.Debug("", zap.Any("Body", string(body)))
+			// Convert the body bytes to string
+			bodyString := string(bodyBytes)
+			logger.Debug("", zap.Any("Body", bodyString))
+			// Rewind the response body to the beginning
+			httpResp.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 		}
 		return nil, utils.ErrorPerStatusCode(httpResp, err)
 	}
@@ -784,12 +829,16 @@ func (c *Client) CreateRulesEngineNextApplication(ctx context.Context, applicati
 			logger.Debug("Error while creating a rules engine", zap.Error(err))
 			logger.Debug("", zap.Any("Status Code", httpResp.StatusCode))
 			logger.Debug("", zap.Any("Headers", httpResp.Header))
-			body, err := io.ReadAll(httpResp.Body)
+			bodyBytes, err := io.ReadAll(httpResp.Body)
 			if err != nil {
 				logger.Debug("Error while reading body of the http response", zap.Error(err))
 				return utils.ErrorPerStatusCode(httpResp, err)
 			}
-			logger.Debug("", zap.Any("Body", string(body)))
+			// Convert the body bytes to string
+			bodyString := string(bodyBytes)
+			logger.Debug("", zap.Any("Body", bodyString))
+			// Rewind the response body to the beginning
+			httpResp.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 		}
 		logger.Debug("", zap.Any("Error", err.Error()))
 		return utils.ErrorPerStatusCode(httpResp, err)
@@ -823,12 +872,16 @@ func (c *Client) CreateRulesEngineNextApplication(ctx context.Context, applicati
 			logger.Debug("Error while creating a rules engine", zap.Error(err))
 			logger.Debug("", zap.Any("Status Code", httpResp.StatusCode))
 			logger.Debug("", zap.Any("Headers", httpResp.Header))
-			body, err := io.ReadAll(httpResp.Body)
+			bodyBytes, err := io.ReadAll(httpResp.Body)
 			if err != nil {
 				logger.Debug("Error while reading body of the http response", zap.Error(err))
 				return utils.ErrorPerStatusCode(httpResp, err)
 			}
-			logger.Debug("", zap.Any("Body", string(body)))
+			// Convert the body bytes to string
+			bodyString := string(bodyBytes)
+			logger.Debug("", zap.Any("Body", bodyString))
+			// Rewind the response body to the beginning
+			httpResp.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 		}
 	}
 

--- a/pkg/api/edge_functions/edge_functions.go
+++ b/pkg/api/edge_functions/edge_functions.go
@@ -1,6 +1,7 @@
 package edge_functions
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"net/http"
@@ -114,12 +115,16 @@ func (c *Client) Create(ctx context.Context, req *CreateRequest) (EdgeFunctionRe
 			logger.Debug("Error while creating an edge function", zap.Error(err))
 			logger.Debug("", zap.Any("Status Code", httpResp.StatusCode))
 			logger.Debug("", zap.Any("Headers", httpResp.Header))
-			body, err := io.ReadAll(httpResp.Body)
+			bodyBytes, err := io.ReadAll(httpResp.Body)
 			if err != nil {
 				logger.Debug("Error while reading body of the http response", zap.Error(err))
 				return nil, utils.ErrorPerStatusCode(httpResp, err)
 			}
-			logger.Debug("", zap.Any("Body", string(body)))
+			// Convert the body bytes to string
+			bodyString := string(bodyBytes)
+			logger.Debug("", zap.Any("Body", bodyString))
+			// Rewind the response body to the beginning
+			httpResp.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 		}
 		return nil, utils.ErrorPerStatusCode(httpResp, err)
 	}
@@ -137,12 +142,16 @@ func (c *Client) Update(ctx context.Context, req *UpdateRequest) (EdgeFunctionRe
 			logger.Debug("Error while updating an edge function", zap.Error(err))
 			logger.Debug("", zap.Any("Status Code", httpResp.StatusCode))
 			logger.Debug("", zap.Any("Headers", httpResp.Header))
-			body, err := io.ReadAll(httpResp.Body)
+			bodyBytes, err := io.ReadAll(httpResp.Body)
 			if err != nil {
 				logger.Debug("Error while reading body of the http response", zap.Error(err))
 				return nil, utils.ErrorPerStatusCode(httpResp, err)
 			}
-			logger.Debug("", zap.Any("Body", string(body)))
+			// Convert the body bytes to string
+			bodyString := string(bodyBytes)
+			logger.Debug("", zap.Any("Body", bodyString))
+			// Rewind the response body to the beginning
+			httpResp.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 		}
 		return nil, utils.ErrorPerStatusCode(httpResp, err)
 	}

--- a/pkg/api/edge_functions/edge_functions.go
+++ b/pkg/api/edge_functions/edge_functions.go
@@ -1,9 +1,7 @@
 package edge_functions
 
 import (
-	"bytes"
 	"context"
-	"io"
 	"net/http"
 	"time"
 
@@ -115,16 +113,10 @@ func (c *Client) Create(ctx context.Context, req *CreateRequest) (EdgeFunctionRe
 			logger.Debug("Error while creating an edge function", zap.Error(err))
 			logger.Debug("", zap.Any("Status Code", httpResp.StatusCode))
 			logger.Debug("", zap.Any("Headers", httpResp.Header))
-			bodyBytes, err := io.ReadAll(httpResp.Body)
+			err := utils.LogAndRewindBody(httpResp)
 			if err != nil {
-				logger.Debug("Error while reading body of the http response", zap.Error(err))
-				return nil, utils.ErrorPerStatusCode(httpResp, err)
+				return nil, err
 			}
-			// Convert the body bytes to string
-			bodyString := string(bodyBytes)
-			logger.Debug("", zap.Any("Body", bodyString))
-			// Rewind the response body to the beginning
-			httpResp.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 		}
 		return nil, utils.ErrorPerStatusCode(httpResp, err)
 	}
@@ -142,16 +134,10 @@ func (c *Client) Update(ctx context.Context, req *UpdateRequest) (EdgeFunctionRe
 			logger.Debug("Error while updating an edge function", zap.Error(err))
 			logger.Debug("", zap.Any("Status Code", httpResp.StatusCode))
 			logger.Debug("", zap.Any("Headers", httpResp.Header))
-			bodyBytes, err := io.ReadAll(httpResp.Body)
+			err := utils.LogAndRewindBody(httpResp)
 			if err != nil {
-				logger.Debug("Error while reading body of the http response", zap.Error(err))
-				return nil, utils.ErrorPerStatusCode(httpResp, err)
+				return nil, err
 			}
-			// Convert the body bytes to string
-			bodyString := string(bodyBytes)
-			logger.Debug("", zap.Any("Body", bodyString))
-			// Rewind the response body to the beginning
-			httpResp.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 		}
 		return nil, utils.ErrorPerStatusCode(httpResp, err)
 	}

--- a/pkg/api/edge_functions/edge_functions.go
+++ b/pkg/api/edge_functions/edge_functions.go
@@ -111,8 +111,6 @@ func (c *Client) Create(ctx context.Context, req *CreateRequest) (EdgeFunctionRe
 	if err != nil {
 		if httpResp != nil {
 			logger.Debug("Error while creating an edge function", zap.Error(err))
-			logger.Debug("", zap.Any("Status Code", httpResp.StatusCode))
-			logger.Debug("", zap.Any("Headers", httpResp.Header))
 			err := utils.LogAndRewindBody(httpResp)
 			if err != nil {
 				return nil, err
@@ -132,8 +130,6 @@ func (c *Client) Update(ctx context.Context, req *UpdateRequest) (EdgeFunctionRe
 	if err != nil {
 		if httpResp != nil {
 			logger.Debug("Error while updating an edge function", zap.Error(err))
-			logger.Debug("", zap.Any("Status Code", httpResp.StatusCode))
-			logger.Debug("", zap.Any("Headers", httpResp.Header))
 			err := utils.LogAndRewindBody(httpResp)
 			if err != nil {
 				return nil, err

--- a/pkg/api/rules_engine/rules_engine.go
+++ b/pkg/api/rules_engine/rules_engine.go
@@ -1,6 +1,7 @@
 package rules_engine
 
 import (
+	"bytes"
 	"context"
 	"io"
 
@@ -17,12 +18,16 @@ func (c *Client) Delete(ctx context.Context, edgeApplicationID int64, phase stri
 			logger.Debug("Error while deleting a rule engine", zap.Error(err))
 			logger.Debug("", zap.Any("Status Code", httpResp.StatusCode))
 			logger.Debug("", zap.Any("Headers", httpResp.Header))
-			body, err := io.ReadAll(httpResp.Body)
+			bodyBytes, err := io.ReadAll(httpResp.Body)
 			if err != nil {
 				logger.Debug("Error while reading body of the http response", zap.Error(err))
 				return utils.ErrorPerStatusCode(httpResp, err)
 			}
-			logger.Debug("", zap.Any("Body", string(body)))
+			// Convert the body bytes to string
+			bodyString := string(bodyBytes)
+			logger.Debug("", zap.Any("Body", bodyString))
+			// Rewind the response body to the beginning
+			httpResp.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 		}
 		return utils.ErrorPerStatusCode(httpResp, err)
 	}

--- a/pkg/api/rules_engine/rules_engine.go
+++ b/pkg/api/rules_engine/rules_engine.go
@@ -1,9 +1,7 @@
 package rules_engine
 
 import (
-	"bytes"
 	"context"
-	"io"
 
 	"github.com/aziontech/azion-cli/pkg/logger"
 	"github.com/aziontech/azion-cli/utils"
@@ -18,16 +16,10 @@ func (c *Client) Delete(ctx context.Context, edgeApplicationID int64, phase stri
 			logger.Debug("Error while deleting a rule engine", zap.Error(err))
 			logger.Debug("", zap.Any("Status Code", httpResp.StatusCode))
 			logger.Debug("", zap.Any("Headers", httpResp.Header))
-			bodyBytes, err := io.ReadAll(httpResp.Body)
+			err := utils.LogAndRewindBody(httpResp)
 			if err != nil {
-				logger.Debug("Error while reading body of the http response", zap.Error(err))
-				return utils.ErrorPerStatusCode(httpResp, err)
+				return err
 			}
-			// Convert the body bytes to string
-			bodyString := string(bodyBytes)
-			logger.Debug("", zap.Any("Body", bodyString))
-			// Rewind the response body to the beginning
-			httpResp.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 		}
 		return utils.ErrorPerStatusCode(httpResp, err)
 	}

--- a/pkg/api/rules_engine/rules_engine.go
+++ b/pkg/api/rules_engine/rules_engine.go
@@ -14,8 +14,6 @@ func (c *Client) Delete(ctx context.Context, edgeApplicationID int64, phase stri
 	if err != nil {
 		if httpResp != nil {
 			logger.Debug("Error while deleting a rule engine", zap.Error(err))
-			logger.Debug("", zap.Any("Status Code", httpResp.StatusCode))
-			logger.Debug("", zap.Any("Headers", httpResp.Header))
 			err := utils.LogAndRewindBody(httpResp)
 			if err != nil {
 				return err

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -14,7 +14,6 @@ import (
 	"github.com/aziontech/azion-cli/pkg/cmd/describe"
 	"github.com/aziontech/azion-cli/pkg/cmd/list"
 	"github.com/aziontech/azion-cli/pkg/cmd/update"
-  "github.com/aziontech/azion-cli/pkg/cmd/describe"
 
 	deploycmd "github.com/aziontech/azion-cli/pkg/cmd/deploy"
 	devcmd "github.com/aziontech/azion-cli/pkg/cmd/dev"

--- a/pkg/cmd/update/edge_application/edge_application.go
+++ b/pkg/cmd/update/edge_application/edge_application.go
@@ -211,6 +211,7 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 			response, err := client.Update(ctx, &request)
 
 			if err != nil {
+				fmt.Println(err.Error())
 				return fmt.Errorf(msg.ErrorUpdateApplication.Error(), err.Error())
 			}
 

--- a/utils/helpers.go
+++ b/utils/helpers.go
@@ -421,6 +421,8 @@ func AskInput(msg string) (string, error) {
 }
 
 func LogAndRewindBody(httpResp *http.Response) error {
+	logger.Debug("", zap.Any("Status Code", httpResp.StatusCode))
+	logger.Debug("", zap.Any("Headers", httpResp.Header))
 	bodyBytes, err := io.ReadAll(httpResp.Body)
 	if err != nil {
 		logger.Debug("Error while reading body of the http response", zap.Error(err))

--- a/utils/helpers.go
+++ b/utils/helpers.go
@@ -328,7 +328,7 @@ func checkStatusCode400Error(httpResp *http.Response) error {
 		return err
 	}
 
-	return fmt.Errorf("%s", responseBody)
+	return fmt.Errorf("%s", string(responseBody))
 }
 
 func checkNoProduct(body string) error {

--- a/utils/helpers.go
+++ b/utils/helpers.go
@@ -419,3 +419,20 @@ func AskInput(msg string) (string, error) {
 
 	return answer, nil
 }
+
+func LogAndRewindBody(httpResp *http.Response) error {
+	bodyBytes, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		logger.Debug("Error while reading body of the http response", zap.Error(err))
+		return ErrorPerStatusCode(httpResp, err)
+	}
+
+	// Convert the body bytes to string
+	bodyString := string(bodyBytes)
+	logger.Debug("", zap.Any("Body", bodyString))
+
+	// Rewind the response body to the beginning
+	httpResp.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+
+	return nil
+}


### PR DESCRIPTION
**WHAT**
- Reset httpResp.body buffer, so it can be read again. There was an error, where the buffer would be read to create the debug message, however, later, when the function ErrorPerStatusCode would try to read it again, the buffer would be empty. This fixes that, reseting the buffer to its initial state;
- Add all debugs to the function as well;