### PR TITLE
chore: update bundler version to 5.1.0

### DIFF
--- a/pkg/vulcan/vulcan.go
+++ b/pkg/vulcan/vulcan.go
@@ -15,10 +15,10 @@ import (
 const (
 	currentMajor         = 4
 	installEdgeFunctions = "npx --yes %s edge-functions%s %s"
-	firstTimeExecuting   = "@5.0.3"
+	firstTimeExecuting   = "@5.1.0"
 )
 
-var versionVulcan = "@5.0.3"
+var versionVulcan = "@5.1.0"
 
 type VulcanPkg struct {
 	Command          func(flags, params string, f *cmdutil.Factory) string

--- a/pkg/vulcan/vulcan_test.go
+++ b/pkg/vulcan/vulcan_test.go
@@ -105,7 +105,7 @@ func TestCheckVulcanMajor(t *testing.T) {
 		{
 			name: "new major version without last version",
 			args: args{
-				currentVersion: "5.0.3",
+				currentVersion: "5.1.0",
 			},
 			lastVulcanVer:   "",
 			expectedVersion: firstTimeExecuting,
@@ -116,8 +116,8 @@ func TestCheckVulcanMajor(t *testing.T) {
 			args: args{
 				currentVersion: "6.0.0",
 			},
-			lastVulcanVer:   "5.0.3",
-			expectedVersion: "@5.0.3",
+			lastVulcanVer:   "5.1.0",
+			expectedVersion: "@5.1.0",
 			wantErr:         false,
 		},
 		{
@@ -125,8 +125,8 @@ func TestCheckVulcanMajor(t *testing.T) {
 			args: args{
 				currentVersion: "6.0.0",
 			},
-			lastVulcanVer:   "5.0.3",
-			expectedVersion: "@5.0.3",
+			lastVulcanVer:   "5.1.0",
+			expectedVersion: "@5.1.0",
 			wantErr:         false,
 		},
 		{


### PR DESCRIPTION
We're updating the Bundler to version 5.1.0, as it included fixes to build NextJS 14.2.x projects.