### PR TITLE
feat(init): add --template flag for non-interactive initialization

### DIFF
--- a/messages/init/errors.go
+++ b/messages/init/errors.go
@@ -23,4 +23,6 @@ var (
 	ErrorReadingGitignore              = errors.New("Failed to read your .gitignore file")
 	ErrorWritingGitignore              = errors.New("Failed to write to your .gitignore file")
 	ErrorGetProjectInfo                = errors.New("Failed to get project preset")
+
+	ErrorTemplateNotFound = "Template '%s' not found. Run 'azion init' without --template to see available options."
 )

--- a/messages/init/messages.go
+++ b/messages/init/messages.go
@@ -7,7 +7,7 @@ const (
 	EXAMPLE             = "$ azion init\n$ azion init --help\n$ azion init --name testproject"
 	FLAG_NAME           = "The Application's name"
 	FLAG_PRESET         = "The Preset's name"
-	FLAG_TEMPLATE       = "The Template's name"
+	FLAG_TEMPLATE       = "Template name to use for initialization (skips interactive selection)"
 	FLAG_PACKAGE_MANAGE = "Specify the package manager to use (e.g., npm, yarn, pnpm)"
 	FLAG_AUTO           = "If sent, the entire flow of the command will be run without interruptions"
 	FLAG_SYNC           = "Synchronizes the local azion.json file with remote resources. Use this flag when deploying your project from this command"

--- a/pkg/cmd/init/init.go
+++ b/pkg/cmd/init/init.go
@@ -194,19 +194,12 @@ func (cmd *initCmd) Run(c *cobra.Command, _ []string) error {
 
 	// Handle --template flag: skip TUI and match template directly
 	if cmd.template != "" {
-		cmd.auto = true // Implies auto behavior
-
 		// Search all templates across all presets
 		var foundTemplate *Item
 		for _, items := range templateMap {
 			for _, i := range items {
 				if i.Name == cmd.template {
 					foundTemplate = &i
-					break
-				}
-			}
-				if items[i].Name == cmd.template {
-					foundTemplate = &items[i]
 					break
 				}
 			}

--- a/pkg/cmd/init/init.go
+++ b/pkg/cmd/init/init.go
@@ -46,6 +46,7 @@ type initCmd struct {
 	sync                  bool
 	local                 bool
 	SkipFramework         bool
+	template              string
 	packageManager        string
 	pathWorkingDir        string
 	f                     *cmdutil.Factory
@@ -130,6 +131,7 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().BoolVar(&init.sync, "sync", false, msg.FLAG_SYNC)
 	cmd.Flags().BoolVar(&init.local, "local", false, msg.FLAG_LOCAL)
 	cmd.Flags().BoolVar(&init.SkipFramework, "skip-framework-build", false, msg.SkipFrameworkBuild)
+	cmd.Flags().StringVar(&init.template, "template", "", msg.FLAG_TEMPLATE)
 	return cmd
 }
 
@@ -187,38 +189,68 @@ func (cmd *initCmd) Run(c *cobra.Command, _ []string) error {
 		listTemplates[number] = value.Name
 	}
 
-	prompt := &survey.Select{
-		Message:  "Choose a preset:",
-		Options:  listTemplates,
-		PageSize: len(listTemplates),
-	}
-
-	var answer string
-	err = cmd.askOne(prompt, &answer)
-	if err != nil {
-		return err
-	}
-
-	templateOptions := []string{}
-	templateOptionsMap := make(map[string]Item)
-	for _, value := range templateMap[answer] {
-		if value.RequiresAdditionalBuild != nil && *value.RequiresAdditionalBuild {
-			continue
-		}
-		templateOptions = append(templateOptions, value.Name)
-		templateOptionsMap[value.Name] = value
-	}
-
-	promptTemplate := &survey.Select{
-		Message:  "Choose a template:",
-		Options:  templateOptions,
-		PageSize: len(templateOptions),
-	}
-
 	var answerTemplate string
-	err = cmd.askOne(promptTemplate, &answerTemplate)
-	if err != nil {
-		return err
+	templateOptionsMap := make(map[string]Item)
+
+	// Handle --template flag: skip TUI and match template directly
+	if cmd.template != "" {
+		cmd.auto = true // Implies auto behavior
+
+		// Search all templates across all presets
+		var foundTemplate *Item
+		for _, items := range templateMap {
+			for i := range items {
+				if items[i].Name == cmd.template {
+					foundTemplate = &items[i]
+					break
+				}
+			}
+			if foundTemplate != nil {
+				break
+			}
+		}
+
+		if foundTemplate == nil {
+			return fmt.Errorf(msg.ErrorTemplateNotFound, cmd.template)
+		}
+
+		// Set preset and template info
+		// Note: cmd.preset will be set later from templateOptionsMap[answerTemplate].Preset
+		answerTemplate = foundTemplate.Name
+		templateOptionsMap[answerTemplate] = *foundTemplate
+	} else {
+		// Existing TUI flow for preset selection
+		prompt := &survey.Select{
+			Message:  "Choose a preset:",
+			Options:  listTemplates,
+			PageSize: len(listTemplates),
+		}
+
+		var answer string
+		err = cmd.askOne(prompt, &answer)
+		if err != nil {
+			return err
+		}
+
+		templateOptions := []string{}
+		for _, value := range templateMap[answer] {
+			if value.RequiresAdditionalBuild != nil && *value.RequiresAdditionalBuild {
+				continue
+			}
+			templateOptions = append(templateOptions, value.Name)
+			templateOptionsMap[value.Name] = value
+		}
+
+		promptTemplate := &survey.Select{
+			Message:  "Choose a template:",
+			Options:  templateOptions,
+			PageSize: len(templateOptions),
+		}
+
+		err = cmd.askOne(promptTemplate, &answerTemplate)
+		if err != nil {
+			return err
+		}
 	}
 
 	dirPath := cmd.dir()

--- a/pkg/cmd/init/init.go
+++ b/pkg/cmd/init/init.go
@@ -199,7 +199,12 @@ func (cmd *initCmd) Run(c *cobra.Command, _ []string) error {
 		// Search all templates across all presets
 		var foundTemplate *Item
 		for _, items := range templateMap {
-			for i := range items {
+			for _, i := range items {
+				if i.Name == cmd.template {
+					foundTemplate = &i
+					break
+				}
+			}
 				if items[i].Name == cmd.template {
 					foundTemplate = &items[i]
 					break

--- a/pkg/cmd/init/init_test.go
+++ b/pkg/cmd/init/init_test.go
@@ -41,6 +41,7 @@ func Test_initCmd_Run(t *testing.T) {
 		name                  string
 		preset                string
 		auto                  bool
+		template              string
 		packageManager        string
 		pathWorkingDir        string
 		globalFlagAll         bool
@@ -704,6 +705,161 @@ func Test_initCmd_Run(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "valid template name",
+			fields: fields{
+				auto:     true,
+				template: "Angular Boilerplate",
+				fileReader: func(filename string) ([]byte, error) {
+					return []byte(infoJsonData), nil
+				},
+				f: &cmdutil.Factory{
+					Flags: cmdutil.Flags{
+						GlobalFlagAll: false,
+						Format:        "",
+						Out:           "",
+						NoColor:       false,
+					},
+					IOStreams: iostreams.System(),
+					Config:    viper.New(),
+				},
+				globalFlagAll: false,
+				name:          "project-piece",
+				getWorkDir: func() (string, error) {
+					return "/path/full", nil
+				},
+				get: func(url string) (resp *http.Response, err error) {
+					b, err := os.ReadFile("./.fixtures/project_samples.json")
+					if err != nil {
+						return nil, err
+					}
+
+					responseBody := io.NopCloser(bytes.NewReader(b))
+					resp = &http.Response{
+						StatusCode: 200,
+						Body:       responseBody,
+						Header:     make(http.Header),
+					}
+					return resp, nil
+				},
+				readAll:   io.ReadAll,
+				unmarshal: json.Unmarshal,
+				askOne: func(p survey.Prompt,
+					response interface{},
+					opts ...survey.AskOpt,
+				) error {
+					// Should not be called when template flag is provided
+					return errors.New("askOne should not be called when template is provided")
+				},
+				dir: config.Dir,
+				mkdirTemp: func(dir, pattern string) (string, error) {
+					return "", nil
+				},
+				removeAll: os.RemoveAll,
+				rename: func(oldpath, newpath string) error {
+					return nil
+				},
+				mkdir:         func(path string, perm os.FileMode) error { return nil },
+				marshalIndent: json.MarshalIndent,
+				writeFile: func(filename string, data []byte, perm fs.FileMode) error {
+					return nil
+				},
+				changeDir: func(dir string) error { return nil },
+				commandRunnerOutput: func(f *cmdutil.Factory, comm string, envVars []string) (string, error) {
+					return "3.2.1", nil
+				},
+				commandRunInteractive: func(f *cmdutil.Factory, comm string) error {
+					return nil
+				},
+				load: func(filenames ...string) (err error) {
+					os.Setenv("preset", "angular")
+					return nil
+				},
+				git: github.Github{
+					Clone: func(cloneOptions *git.CloneOptions, url, path string) error {
+						return nil
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid template name",
+			fields: fields{
+				auto:     true,
+				template: "NonExistent Template",
+				fileReader: func(filename string) ([]byte, error) {
+					return []byte(infoJsonData), nil
+				},
+				f: &cmdutil.Factory{
+					Flags: cmdutil.Flags{
+						GlobalFlagAll: false,
+						Format:        "",
+						Out:           "",
+						NoColor:       false,
+					},
+					IOStreams: iostreams.System(),
+					Config:    viper.New(),
+				},
+				globalFlagAll: false,
+				name:          "project-piece",
+				getWorkDir: func() (string, error) {
+					return "/path/full", nil
+				},
+				get: func(url string) (resp *http.Response, err error) {
+					b, err := os.ReadFile("./.fixtures/project_samples.json")
+					if err != nil {
+						return nil, err
+					}
+
+					responseBody := io.NopCloser(bytes.NewReader(b))
+					resp = &http.Response{
+						StatusCode: 200,
+						Body:       responseBody,
+						Header:     make(http.Header),
+					}
+					return resp, nil
+				},
+				readAll:   io.ReadAll,
+				unmarshal: json.Unmarshal,
+				askOne: func(p survey.Prompt,
+					response interface{},
+					opts ...survey.AskOpt,
+				) error {
+					return nil
+				},
+				dir: config.Dir,
+				mkdirTemp: func(dir, pattern string) (string, error) {
+					return "", nil
+				},
+				removeAll: os.RemoveAll,
+				rename: func(oldpath, newpath string) error {
+					return nil
+				},
+				mkdir:         func(path string, perm os.FileMode) error { return nil },
+				marshalIndent: json.MarshalIndent,
+				writeFile: func(filename string, data []byte, perm fs.FileMode) error {
+					return nil
+				},
+				changeDir: func(dir string) error { return nil },
+				commandRunnerOutput: func(f *cmdutil.Factory, comm string, envVars []string) (string, error) {
+					return "3.2.1", nil
+				},
+				commandRunInteractive: func(f *cmdutil.Factory, comm string) error {
+					return nil
+				},
+				load: func(filenames ...string) (err error) {
+					os.Setenv("preset", "vite")
+					return nil
+				},
+				git: github.Github{
+					Clone: func(cloneOptions *git.CloneOptions, url, path string) error {
+						return nil
+					},
+				},
+			},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -711,6 +867,7 @@ func Test_initCmd_Run(t *testing.T) {
 				name:                  tt.fields.name,
 				preset:                tt.fields.preset,
 				auto:                  tt.fields.auto,
+				template:              tt.fields.template,
 				packageManager:        tt.fields.packageManager,
 				pathWorkingDir:        tt.fields.pathWorkingDir,
 				f:                     tt.fields.f,
@@ -760,6 +917,7 @@ func Test_initCmd_deps(t *testing.T) {
 		name                  string
 		preset                string
 		auto                  bool
+		template              string
 		packageManager        string
 		pathWorkingDir        string
 		f                     *cmdutil.Factory
@@ -882,6 +1040,7 @@ func Test_initCmd_deps(t *testing.T) {
 				name:                  tt.fields.name,
 				preset:                tt.fields.preset,
 				auto:                  tt.fields.auto,
+				template:              tt.fields.template,
 				packageManager:        tt.fields.packageManager,
 				pathWorkingDir:        tt.fields.pathWorkingDir,
 				f:                     tt.fields.f,


### PR DESCRIPTION
Add --template flag to azion init command that allows users to specify a template name directly, skipping the interactive preset/template TUI. When provided, the flag implies --auto behavior.

- Add ErrorTemplateNotFound error message
- Update FLAG_TEMPLATE description
- Add template field to initCmd struct
- Implement template matching logic in Run() method
- Add tests for valid and invalid template names